### PR TITLE
service settings.dynamicConfig

### DIFF
--- a/example-repo/packages/api/src/routes/index.ts
+++ b/example-repo/packages/api/src/routes/index.ts
@@ -16,7 +16,7 @@ router.get('/', async (ctx) => {
   // TODO: add something which checks redis and postgres connections are working
   ctx.body = {
     systemStatus: 'nope',
-    envCheck: process.dmnoEnv.API_ONLY || 'env-var-not-loaded',
+    envCheck: DMNO_CONFIG.API_ONLY || 'env-var-not-loaded',
     dmnoTest: DMNO_CONFIG.PORT,
   };
 });

--- a/example-repo/packages/astro-web/.dmno/config.mts
+++ b/example-repo/packages/astro-web/.dmno/config.mts
@@ -6,6 +6,9 @@ const OnePassBackend = OnePasswordDmnoPlugin.injectInstance('1pass');
 export default defineDmnoService({
   name: 'astroweb',
   parent: 'group1',
+  settings: {
+    dynamicConfig: 'default_static',
+  },
   pick: [
     'NODE_ENV',
     'DMNO_ENV',

--- a/example-repo/packages/astro-web/astro.config.ts
+++ b/example-repo/packages/astro-web/astro.config.ts
@@ -8,9 +8,7 @@ import node from "@astrojs/node";
 // https://astro.build/config
 export default defineConfig({
   integrations: [
-    dmnoAstroIntegration({
-      dynamicPublicConfig: !!process.env.TEST_ASTRO_SSR && true
-    }),
+    dmnoAstroIntegration(),
     vue(),
     mdx(),
     // {

--- a/example-repo/packages/nextjs-web/package.json
+++ b/example-repo/packages/nextjs-web/package.json
@@ -7,7 +7,6 @@
     "build": "NODE_ENV=production SECRET_STATIC=secret-static-build SECRET_DYNAMIC=secret-dynamic-build PUBLIC_STATIC=ps-build PUBLIC_DYNAMIC=pd-build dmno run -- next build",
     "build:static": "NODE_ENV=production NEXT_OUTPUT_EXPORT=1 pnpm build",
     "start": "NODE_ENV=production SECRET_STATIC=secret-static-boot SECRET_DYNAMIC=secret-dynamic-boot PUBLIC_STATIC=ps-boot PUBLIC_DYNAMIC=pd-boot dmno run -- next start",
-    "start2": "next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/example-repo/packages/nextjs-web/src/app/api/route.ts
+++ b/example-repo/packages/nextjs-web/src/app/api/route.ts
@@ -18,8 +18,5 @@ export async function GET() {
     
     // throws an error
     // publicError: DMNO_PUBLIC_CONFIG.ASDF,
-    
-    // throws an error
-    // privateError: process.dmnoEnv.ASDF,
   })
 }

--- a/packages/core/src/cli/commands/run.command.ts
+++ b/packages/core/src/cli/commands/run.command.ts
@@ -93,7 +93,7 @@ program.action(async (_command, opts: {
         env: {
           ...process.env,
           ...serviceEnv,
-          DMNO_LOADED_ENV: JSON.stringify(service.getLoadedEnv()),
+          DMNO_LOADED_ENV: JSON.stringify(service.getInjectedEnvJSON()),
         },
       });
       // console.log('PARENT PID = ', process.pid);

--- a/packages/core/src/cli/lib/formatting.ts
+++ b/packages/core/src/cli/lib/formatting.ts
@@ -84,8 +84,8 @@ export function getItemSummary(item: SerializedConfigItem) {
   const summary: Array<string> = [];
   const icon = item.coercionError?.icon || item.resolutionError?.icon || item?.validationErrors?.[0]?.icon || '✅';
   // item.resolvedValue === undefined ? '✅' : '✅';
-  const isSensitive = item.dataType.sensitive;
-  const isRequired = item.dataType.required;
+  const isSensitive = item.dataType?.sensitive;
+  const isRequired = item.dataType?.required;
   summary.push(joinAndCompact([
     icon,
     kleur[item.isValid ? 'cyan' : 'red'](item.key) + (isRequired ? kleur.magenta('*') : ''),

--- a/packages/core/src/config-engine/base-types.ts
+++ b/packages/core/src/config-engine/base-types.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash-es';
 import {
   ConfigItemDefinition, ResolverContext, TypeValidationResult,

--- a/packages/core/src/config-loader/config-server-client.ts
+++ b/packages/core/src/config-loader/config-server-client.ts
@@ -277,8 +277,8 @@ export function injectDmnoGlobals(dmnoService: SerializedService, trackAccess?: 
       const keyStr = key.toString();
       if (trackAccess) trackAccess[keyStr] = true;
       // console.log('get DMNO_PUBLIC_CONFIG - ', keyStr);
-      if (dmnoService.config[keyStr].dataType.sensitive) {
-        throw new Error(`❌ ${keyStr} is not a public config item!`);
+      if (dmnoService.config[keyStr]?.dataType.sensitive) {
+        throw new Error(`❌ ${keyStr} is not a public config item! Use \`DMNO_CONFIG.${keyStr}\` instead`);
       }
       if (key in dmnoEnvValues) return dmnoEnvValues[keyStr];
       throw new Error(`❌ ${keyStr} is not a config item (2)`);

--- a/packages/core/src/config-loader/serialization-types.ts
+++ b/packages/core/src/config-loader/serialization-types.ts
@@ -49,7 +49,7 @@ export type SerializedDmnoPluginInput = Pick<DmnoPluginInputItem, 'key' | 'isVal
 };
 
 export type SerializedConfigItem =
-  Pick<DmnoConfigItemBase, 'key' | 'isValid' | 'resolvedRawValue' | 'resolvedValue' | 'isResolved'>
+  Pick<DmnoConfigItemBase, 'key' | 'isValid' | 'resolvedRawValue' | 'resolvedValue' | 'isResolved' | 'isDynamic'>
   & {
     dataType: SerializedDmnoDataType,
     children: Record<string, SerializedConfigItem>,

--- a/packages/docs-site/src/content/docs/docs/guides/dynamic-config.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/dynamic-config.mdx
@@ -20,23 +20,25 @@ Then in your code, simply use `DMNO_CONFIG` and `DMNO_PUBLIC_CONFIG` and we take
 
 ### Default dynamic behavior
 
-How items are treated by default (with respect to being dynamic) is something that likely depends on the kind of app/service you are building and how it will be deployed. So rather than forcing you with a single way, we let you control this default behaviour with the `dynamicConfig` in your service config (`defineDmnoService()`).
+How items are treated by default (with respect to being dynamic) is something that likely depends on the kind of app/service you are building and how it will be deployed, so we let you control this default behaviour with the `settings.dynamicConfig` property in your service config.
 
 The following table shows the different modes supported:
 
 |value | description|
 |---|---|
-| `public_static`<br/>_(default)_ | **non-sensitive = static, sensitive = dynamic**<br/>_use `dynamic: true \| false` option to override_|
+| `public_static`<br/>⭐ _default_ | **non-sensitive = static, sensitive = dynamic**<br/>_use `dynamic: true \| false` option to override_|
 | `only_static` | **everything static, dynamic not supported**<br/>_useful for static/SSG sites_ |
 | `only_dynamic` | **everything dynamic, static not supported**<br/>_useful for a backend app and not using any bundler_ |
 | `default_static` | **default is static**<br/>_use `dynamic: true` to override_ |
 | `default_dynamic` | **default is dynamic**<br/>_use `dynamic: false` to override_ |
 
-An example schema:
+An example service schema using the `dynamicConfig` service setting and item overrides:
 
 ```diff lang="ts" ins="dynamic: true"
 export default defineDmnoService({
-+  dynamicConfig: 'default_static',
++  settings: {
++    dynamicConfig: 'default_static',
++  },
   schema: {    
     PUBLIC_STATIC: {},
     PUBLIC_DYNAMIC: { dynamic: true },
@@ -45,6 +47,13 @@ export default defineDmnoService({
   }
 })
 ```
+:::tip[Default behavior]
+The default "dynamic config mode" is `public_static` which matches what you are probably used to with other tools - sensitive items are dynamic and non-sensitive items are static.
+:::
+
+:::note[Service settings inheritance]
+Service "settings" are inherited up through the chain of parent services if left unspecified.
+:::
 
 
 ### Fetching dynamic config on the client

--- a/packages/docs-site/src/content/docs/docs/guides/frameworks/astro.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/frameworks/astro.mdx
@@ -117,9 +117,9 @@ So we make it easy for you:
 
 DMNO gives you explicit control over how your config items are treated - whether they will be replaced into your bundled code at build time (static), or reloaded at boot time (dynamic). See the [dynamic config guide](/docs/guides/dynamic-config) for more details.
 
-As for features related to dynamic config, this integration will:
-- automatically inject the API route required to fetch public+dynamic config (if you have any in your schema)
-- warn you if you accidentally use a dynamic config item during a pre-render - regardless of the [output mode](https://docs.astro.build/en/basics/rendering-modes/#server-output-modes) you are using
+Client-side loading of dynamic config is automatically enabled if you are not using `output: 'static'` mode and you have non-sensitive dynamic config items in your schema. It will fetched on-demand, so if you don't use those items on the client, that's also fine. This integration will automatically inject the API route required to fetch public+dynamic config.
+
+Additionally, this integration throws an error during `astro build` if you try to use a dynamic config item during a pre-render of any static page/endpoint - regardless of the [output mode](https://docs.astro.build/en/basics/rendering-modes/#server-output-modes) you are using.
 
 ---
 


### PR DESCRIPTION
allows us to toggle the default behaviour (per service) for making items  "dynamic".

This also introduces the notion of "service settings" that can be inherited from their parents, as I suspect we'll have more settings like this.