### PR TITLE
update instructions to use `dmno init`

### DIFF
--- a/packages/core/src/cli/lib/init-helpers.ts
+++ b/packages/core/src/cli/lib/init-helpers.ts
@@ -107,7 +107,7 @@ function installPackage(
 
 const KNOWN_INTEGRATIONS_MAP = Object.freeze({
   astro: '@dmno/astro-integration',
-  nextjs: '@dmno/nextjs-integration',
+  next: '@dmno/nextjs-integration',
   vite: '@dmno/vite-integration',
   express: 'dmno',
   koa: 'dmno',

--- a/packages/docs-site/src/components/HeaderNav.astro
+++ b/packages/docs-site/src/components/HeaderNav.astro
@@ -13,7 +13,7 @@ import DIcon from "./DIcon.astro";
     />
     .docs
   </a>
-  <!-- <a
+  <a
     href="/blog"
     title="cd ./.blog"
     aria-current={Astro.url.pathname.startsWith("/blog") ? "page" : undefined}
@@ -22,7 +22,7 @@ import DIcon from "./DIcon.astro";
       name={Astro.url.pathname.startsWith("/blog") ? "folder-open" : "folder"}
     />
     .blog
-  </a> -->
+  </a>
 </nav>
 
 <style lang="less">

--- a/packages/docs-site/src/components/TabbedCode.astro
+++ b/packages/docs-site/src/components/TabbedCode.astro
@@ -44,7 +44,7 @@ const platforms = [
   {
     platforms.map((platform) => (
       <TabItem label={platform.name}>
-        <Code lang="bash" code={platform[variant]} />
+        <Code lang="bash" code={platform[variant as keyof typeof platform]} />
       </TabItem>
     ))
   }

--- a/packages/docs-site/src/components/TabbedCode.astro
+++ b/packages/docs-site/src/components/TabbedCode.astro
@@ -1,26 +1,41 @@
 ---
 import { Tabs, TabItem, Code } from "@astrojs/starlight/components";
 // import DmnoTabs from "./DmnoTabs.astro";
-import { currentPm } from "./store";
 
-const { packageName, command } = Astro.props;
+const { packageName, command, dynamicExec } = Astro.props;
 
-const variant = packageName ? "packageName" : "command";
+let variant;
+switch (true) {
+  case Boolean(packageName):
+    variant = "packageName";
+    break;
+  case Boolean(command):
+    variant = "command";
+    break;
+  default:
+    variant = "dynamicExec";
+    break;
+}; 
+
 const platforms = [
   {
     name: "npm",
     packageName: `npm add ${packageName}`,
     command: `npm exec -- ${command}`,
+    dynamicExec: `npx ${dynamicExec}`,
+
   },
   {
     name: "pnpm",
     packageName: `pnpm add ${packageName}`,
     command: `pnpm exec ${command}`,
+    dynamicExec: `pnpm dlx ${dynamicExec}`,
   },
   {
     name: "Yarn",
     packageName: `yarn add ${packageName}`,
     command: `yarn exec -- ${command}`,
+    dynamicExec: `yarn dlx ${dynamicExec}`,
   },
 ];
 ---

--- a/packages/docs-site/src/content/docs/blog/hello-dmno.md
+++ b/packages/docs-site/src/content/docs/blog/hello-dmno.md
@@ -1,12 +1,9 @@
 ---
 title: Announcing DMNO's Developer Preview
 date:  2024-04-30
-draft: true
 ---
 
 ## Hello DMNO 👋
-
-![DMNO_Overview.gif](https://media.giphy.com/media/3o7TKz3v6zrjg1Z1Qc/giphy.gif)
 
 We (Theo and Phil), are happy to announce the Developer Preview of our new project, DMNO. Our first release is a configuration engine that helps you manage your configuration in a single place, and access it in a type-safe way across your services.
 
@@ -27,8 +24,6 @@ We've also created a few plugins to help you securely manage your secrets and ot
 To get started you can check out our [quickstart guide](/docs/get-started/quickstart), or dive into our [schema guide](/docs/guides/schema).
 
 We've also create a short video that goes over the basics of DMNO, and how it can help you manage your configuration. Check it out below:
-
-![DMNO_Overview.gif](https://media.giphy.com/media/3o7TKz3v6zrjg1Z1Qc/giphy.gif)
 
 ## What's next?
 

--- a/packages/docs-site/src/content/docs/docs/get-started/quickstart.mdx
+++ b/packages/docs-site/src/content/docs/docs/get-started/quickstart.mdx
@@ -9,13 +9,10 @@ import TabbedCode from '@/components/TabbedCode.astro';
 
 <Steps>
 
-1. ### **Install `dmno`**
-    <TabbedCode packageName="dmno" />
-
-2. ### **Initialize `dmno` in your project**
+1. ### **Setup `dmno` in your project**
 
     Run this command in the root of your project:
-    <TabbedCode command="dmno init" />
+    <TabbedCode dynamicExec="dmno init" />
 
     ![dmno init](../../../../assets/tapes/init.gif)
 
@@ -35,24 +32,24 @@ import TabbedCode from '@/components/TabbedCode.astro';
 
     </FileTree>
 
-3. ### **Start the development server**
+2. ### **Start the development server**
 
     This will give you instant feedback while you author your config schema.
     <TabbedCode command="dmno dev" />
 
     ![dmno init](../../../../assets/tapes/dev.gif)
 
-4. ### **Write your schema**
+3. ### **Write your schema**
 
     The config schema and other settings live in the `.dmno/config.mts` files. Defining each item with a description, [`required`](/docs/guides/schema#validations--required-config), and [`sensitive`](/docs/guides/schema#secrets--security) is a great first step. You can then improve your schema over time, adding validations, and setting values from within the schema itself.
 
     Check out the [schema guide](/docs/guides/schema) for full details.
 
-5. ### **Install framework specific integrations**
+4. ### **Install framework specific integrations**
 
     We provide [drop-in integrations](/docs/integrations/overview) for many popular frameworks, and more are in the works. Install the relevant integrations in your services according to their instructions - this is the fastest way to get started.
 
-6. ### **Use `DMNO_CONFIG` to access your config** 
+5. ### **Use `DMNO_CONFIG` to access your config** 
 
      We recommend migrating to `DMNO_CONFIG` as it provides helpful improvements like TypeScript autocompletion and IntelliSense.
       

--- a/packages/docs-site/src/content/docs/docs/get-started/quickstart.mdx
+++ b/packages/docs-site/src/content/docs/docs/get-started/quickstart.mdx
@@ -47,7 +47,7 @@ import TabbedCode from '@/components/TabbedCode.astro';
 
 4. ### **Install framework specific integrations**
 
-    We provide [drop-in integrations](/docs/integrations/overview) for many popular frameworks, and more are in the works. Install the relevant integrations in your services according to their instructions - this is the fastest way to get started.
+    We provide [drop-in integrations](/docs/integrations/overview) for many popular frameworks, and more are in the works. `dmno init` is smart enough to install the relevant integrations for each service. You can also read more about each integration on their respective [pages](docs/integrations/overview).
 
 5. ### **Use `DMNO_CONFIG` to access your config** 
 

--- a/packages/docs-site/src/content/docs/docs/integrations/astro.mdx
+++ b/packages/docs-site/src/content/docs/docs/integrations/astro.mdx
@@ -12,11 +12,11 @@ At DMNO we _love_ Astro. This very site is built with it! That's why we're very 
 
 ## Setup
 
-### Install the `dmno` Astro integration
+### Initialize your Astro integration
 
-Using Astro's `add` command will automatically install dependencies and update your Astro config.
+Using `dmno init` we will automatically detect that you are using Astro and install the necessary packages and configuration for you.
 
-<TabbedCode command="astro add @dmno/astro-integration" />
+<TabbedCode dynamicExec="dmno init" />
 
 >Skip to [Scaffold...](#scaffold-your-dmno-config) once this is complete.
 
@@ -41,14 +41,6 @@ export default defineConfig({
   integrations: [dmnoAstroIntegration()],
 });
 ```
-
-### Scaffold your DMNO config
-
-Next, run the following command in a terminal at the root of your repo:
-
-<TabbedCode command="dmno init" />
-
-This will create a `.dmno` directory in the root of your project with a `config.mts` file. And it will also create `.dmno` folders and config files in each of the other directories for other apps/services (at your discretion) if you have a monorepo.
 
 ### Configure your environment variables
 

--- a/packages/docs-site/src/content/docs/docs/integrations/astro.mdx
+++ b/packages/docs-site/src/content/docs/docs/integrations/astro.mdx
@@ -18,7 +18,7 @@ Using `dmno init` we will automatically detect that you are using Astro and inst
 
 <TabbedCode dynamicExec="dmno init" />
 
->Skip to [Scaffold...](#scaffold-your-dmno-config) once this is complete.
+>Skip to [Configure...](#configure-your-environment-variables) once this is complete.
 
 :::note
 If you run into any issues, feel free to <BugReportLink label='integrations/astro'>report them to us on GitHub</BugReportLink> and try the manual installation steps below.

--- a/packages/docs-site/src/content/docs/docs/integrations/nextjs.mdx
+++ b/packages/docs-site/src/content/docs/docs/integrations/nextjs.mdx
@@ -12,18 +12,15 @@ Now forget all of that, and let's simplify things with DMNO. 🥳
 
 ### Install dependencies
 
-First, install the `dmno` and `@dmno/nextjs-integration` packages.
+First let `dmno init` scaffold your project and install `dmno`. 
 
-<TabbedCode packageName="dmno @dmno/next-integration" />
+<TabbedCode dynamicExec="dmno init" />
 
-### Scaffold your DMNO config
+### Add the Next.js integration
 
-Run the following command in a terminal at the root of your repo:
+Next, install `@dmno/nextjs-integration`.
 
-<TabbedCode command="dmno init" />
-
-This will create a `.dmno` directory in the root of your project with a `config.mts` file. And it will also create `.dmno` folders and config files in each of the other directories for other apps/services if you have a monorepo.
-
+<TabbedCode packageName="@dmno/nextjs-integration" />
 
 ### Configure your environment variables
 

--- a/packages/docs-site/src/content/docs/docs/integrations/vite.mdx
+++ b/packages/docs-site/src/content/docs/docs/integrations/vite.mdx
@@ -7,17 +7,13 @@ import TabbedCode from '@/components/TabbedCode.astro';
 
 At DMNO we're big fans of [Vite](https://vitejs.dev/), which is why we offer first class integration between Vite and DMNO. 
 
-To get started, install `dmno` and the `vite` plugin: 
+## Init
 
-<TabbedCode packageName="@dmno/vite-integration dmno" />
+To get started, `dmno init` will scaffold your project and install `dmno` and the `vite-integration` package. 
 
-### Scaffold your DMNO config
+<TabbedCode dynamicExec="dmno init" />
 
-Next, run the following command in a terminal at the root of your repo:
-
-<TabbedCode command="dmno init" />
-
-This will create a `.dmno` directory in the root of your project with a `config.mts` file. And it will also create `.dmno` folders and config files in each of the other directories for other apps/services if you have a monorepo.
+This will create a `.dmno` directory in the root of your project with a `config.mts` file.
 
 ### Configure your environment variables    
 
@@ -26,7 +22,7 @@ See our [Schema Guide](/docs/guides/schema) for the specifics of how to write yo
 
 ## Setup
 
-### Install the dmno vite plugin
+### Configure the dmno vite plugin
 
 Update your `vite.config.ts` - import the plugin, and add to `defineConfig`:
 

--- a/packages/docs-site/src/content/docs/docs/reference/cli/commands.mdx
+++ b/packages/docs-site/src/content/docs/docs/reference/cli/commands.mdx
@@ -10,6 +10,10 @@ The `dmno` cli was installed when you [installed](/docs/get-started/quickstart) 
 
 The `dmno` cli  provides a number of commands to help you run and manage your DMNO projects.
 
+:::note
+The `dmno` cli is installed as a depedency in your project and is available in your `node_modules/.bin` directory. You can also add it to your `PATH` to run it without using `npm exec`/`npx` or the equivalent in other package managers. For simplicity's sake, we will omit the `npm exec`/`npx` prefix in the examples below.
+:::
+
 ### Commands
 
 - [`dmno init`](/docs/reference/cli/init) - Initialize a new DMNO project


### PR DESCRIPTION
simplifies install instructions where possible (astro + vite) and adds variant of `TabbedCode` to use `npx/dlx/etc` 