### PR TITLE
use custom conditions to use and link directly to ts-src during local…

### DIFF
--- a/example-repo/packages/astro-web/tsconfig.json
+++ b/example-repo/packages/astro-web/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "customConditions": [ "ts-src" ]
   },
   "exclude": [ "dist", "~partytown" ]
 }

--- a/example-repo/packages/nextjs-web/tsconfig.json
+++ b/example-repo/packages/nextjs-web/tsconfig.json
@@ -19,7 +19,8 @@
     ],
     "paths": {
       "@/*": [ "./src/*" ]
-    }
+    },
+    "customConditions": [ "ts-src" ]
   },
   "include": [
     "next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts",

--- a/example-repo/packages/webapp/tsconfig.node.json
+++ b/example-repo/packages/webapp/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "customConditions": [ "ts-src" ]
   },
   "include": [
     "vite.config.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,47 +34,42 @@
   "engines": {
     "node": ">=16"
   },
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs"
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./vendor-types": {
-      "default": "./dist/vendor-types/index.mjs"
+      "ts-src": "./src/vendor-types/index.ts",
+      "import": "./dist/vendor-types/index.js",
+      "types": "./dist/vendor-types/index.d.ts"
     },
     "./cli-lib": {
-      "default": "./dist/cli/plugin-cli-lib.mjs"
+      "ts-src": "./src/cli/plugin-cli-lib.ts",
+      "import": "./dist/cli/plugin-cli-lib.js",
+      "types": "./dist/cli/plugin-cli-lib.d.ts"
     },
     "./injector": {
-      "default": "./dist/inject/dmno-globals-injector.mjs"
+      "ts-src": "./src/inject/dmno-globals-injector.ts",
+      "import": "./dist/inject/dmno-globals-injector.js",
+      "types": "./dist/inject/dmno-globals-injector.d.ts"
     },
     "./inject": {
-      "default": "./dist/inject/inject-dmno-globals.mjs"
-    }
+      "ts-src": "./src/inject/inject-dmno-globals.ts",
+      "import": "./dist/inject/inject-dmno-globals.js",
+      "types": "./dist/inject/inject-dmno-globals.d.ts"
+    },
+    "./tsconfigs/*.json": "./tsconfigs/*",
+    "./tsconfigs/*": "./tsconfigs/*.json"
   },
   "files": [
-    "/dist"
+    "/dist",
+    "/tsconfigs"
   ],
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/index.d.mts"
-      ],
-      "vendor-types": [
-        "./dist/vendor-types/index.d.mts"
-      ],
-      "cli-lib": [
-        "./dist/cli/plugin-cli-lib.d.mts"
-      ],
-      "injector": [
-        "./dist/inject/dmno-globals-injector.d.mts"
-      ],
-      "inject": [
-        "./dist/inject/inject-dmno-globals.d.mts"
-      ]
-    }
-  },
   "bin": {
-    "dmno": "./dist/cli/cli-executable.mjs"
+    "dmno": "./dist/cli/cli-executable.js"
   },
   "devDependencies": {
     "@dmno/encryption-lib": "workspace:*",

--- a/packages/core/src/cli/commands/plugin.command.ts
+++ b/packages/core/src/cli/commands/plugin.command.ts
@@ -39,7 +39,8 @@ program.action(async (opts: {
   let cliPath = ctx.selectedPlugin.cliPath;
 
   if (!cliPath) throw new Error('no cli for this plugin!');
-  if (!cliPath.endsWith('.mjs')) cliPath += '.mjs';
+  // TODO: might want to look for .js and .mjs?
+  if (!cliPath.endsWith('.js')) cliPath += '.js';
 
   // console.log(more.args);
 

--- a/packages/core/src/cli/lib/init-helpers.ts
+++ b/packages/core/src/cli/lib/init-helpers.ts
@@ -24,9 +24,7 @@ const STEP_DELAY = 300;
 
 const DMNO_FOLDER_TSCONFIG = outdent`
   {
-    "compilerOptions": {
-      "strict": true
-    },
+    "extends": "dmno/tsconfigs/dmno-folder",
     "include": [
       "./**/*.mts",
       "./.typegen/global.d.ts"

--- a/packages/core/src/config-loader/vite-server.ts
+++ b/packages/core/src/config-loader/vite-server.ts
@@ -25,7 +25,7 @@ export async function setupViteServer(
         return {
           // pointing at dist/index is hard-coded...
           // we could extract the main entry point from the resolution instead?
-          id: '/node_modules/dmno/dist/index.mjs',
+          id: '/node_modules/dmno/dist/index.js',
           // I believe this path is appended to our "root" which is our workpace root
         };
       }

--- a/packages/core/tsconfigs/dmno-folder.json
+++ b/packages/core/tsconfigs/dmno-folder.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
+  }
+}

--- a/packages/docs-site/astro.config.ts
+++ b/packages/docs-site/astro.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
         compiler: 'raw',
       }),
     ],
+    // resolve: {
+    //   conditions: ['ts-src'],
+    // },
   },
   trailingSlash: 'always',
   integrations: [

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -50,6 +50,5 @@
     "@iconify/json": "^2.2.212",
     "netlify-cli": "^17.23.5",
     "typedoc": "^0.25.13"
-  },
-  "version": null
+  }
 }

--- a/packages/docs-site/tsconfig.json
+++ b/packages/docs-site/tsconfig.json
@@ -12,7 +12,8 @@
     },
     "types": [
       "unplugin-icons/types/raw"
-    ]
+    ],
+    "customConditions": [ "ts-src" ]
   },
   "exclude": [ "dist", "~partytown" ]
 }

--- a/packages/integrations/astro/package.json
+++ b/packages/integrations/astro/package.json
@@ -22,19 +22,15 @@
     "astro-integration",
     "dmno-integration"
   ],
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs"
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./meta": {
       "default": "./dmno.meta.json"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/index.d.mts"
-      ]
     }
   },
   "files": [

--- a/packages/integrations/astro/src/index.ts
+++ b/packages/integrations/astro/src/index.ts
@@ -253,18 +253,18 @@ function dmnoAstroIntegration(dmnoIntegrationOpts?: DmnoAstroIntegrationOptions)
           injectRoute({
             pattern: 'public-dynamic-config.json',
             // Use relative path syntax for a local route.
-            entrypoint: `${__dirname}/fetch-public-dynamic-config.json.mjs`,
+            entrypoint: `${__dirname}/fetch-public-dynamic-config.json.js`,
           });
         }
 
         // add leak detection middleware!
         addMiddleware({
-          entrypoint: `${__dirname}/astro-middleware.mjs`,
+          entrypoint: `${__dirname}/astro-middleware.js`,
           order: 'post', // not positive on this?
         });
 
         // enable the toolbar (currently does nothing...)
-        addDevToolbarApp(`${__dirname}/dev-toolbar-app.mjs`);
+        addDevToolbarApp(`${__dirname}/dev-toolbar-app.js`);
       },
       'astro:build:done': async (opts) => {
         // if we didn't actually pre-render any pages, we can move one

--- a/packages/integrations/nextjs/package.json
+++ b/packages/integrations/nextjs/package.json
@@ -22,22 +22,21 @@
     "integration",
     "dmno-integration"
   ],
+
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs"
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./meta": {
       "default": "./dmno.meta.json"
     },
     "./inject": {
-      "default": "./dist/inject-dmno-server.mjs"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/index.d.mts"
-      ]
+      "ts-src": "./src/inject-dmno-server.ts",
+      "import": "./dist/inject-dmno-server.js",
+      "types": "./dist/inject-dmno-server.d.ts"
     }
   },
   "files": [

--- a/packages/integrations/nextjs/src/index.ts
+++ b/packages/integrations/nextjs/src/index.ts
@@ -38,7 +38,7 @@ export function dmnoNextConfigPlugin() {
           // it doesnt get run while next is doing a build and analyzing all the routes :(
           // so for now, we'll force users to import manually
           // if (isServer) {
-          //   const injectDmnoServerFilePath = `${import.meta.dirname}/inject-dmno-server.mjs`;
+          //   const injectDmnoServerFilePath = `${import.meta.dirname}/inject-dmno-server.js`;
           //   injectEntry('pages/_app', injectDmnoServerFilePath);
           //   injectEntry('pages/_document', injectDmnoServerFilePath);
           // }
@@ -46,7 +46,7 @@ export function dmnoNextConfigPlugin() {
           // injects our DMNO_CONFIG shims into the client
           // which gives us nicer errors and also support for dynamic public config
           if (!isServer) {
-            const injectDmnoClientFilePath = `${import.meta.dirname}/inject-dmno-client.mjs`;
+            const injectDmnoClientFilePath = `${import.meta.dirname}/inject-dmno-client.js`;
             injectEntry('main-app', injectDmnoClientFilePath);
           }
 

--- a/packages/integrations/vite/package.json
+++ b/packages/integrations/vite/package.json
@@ -22,19 +22,15 @@
     "vite plugin",
     "dmno-integration"
   ],
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs"
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./meta": {
       "default": "./dmno.meta.json"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/index.d.mts"
-      ]
     }
   },
   "files": [

--- a/packages/platforms/netlify/package.json
+++ b/packages/platforms/netlify/package.json
@@ -23,20 +23,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/build-plugin/index.js"
+      "default": "./dist/build-plugin/index.js",
+      "types": "./dist/build-plugin/index.d.ts"
     },
     "./types": {
-      "default": "./dist/index.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/build-plugin/index.d.ts"
-      ],
-      "types": [
-        "./dist/index.d.ts"
-      ]
+      "ts-src": "./src/index.js",
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [

--- a/packages/platforms/netlify/tsconfig.json
+++ b/packages/platforms/netlify/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist",
     "lib": [
       "ESNext"
-    ]
+    ],
+    "rootDir": "src",
   },
   "include": [
     "src/**/*.ts",

--- a/packages/plugins/1password/package.json
+++ b/packages/plugins/1password/package.json
@@ -20,16 +20,12 @@
     "secrets",
     "dmno-plugin"
   ],
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/index.d.mts"
-      ]
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [

--- a/packages/plugins/encrypted-vault/package.json
+++ b/packages/plugins/encrypted-vault/package.json
@@ -23,16 +23,12 @@
     "secrets",
     "dmno-plugin"
   ],
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "index": [
-        "./dist/index.d.mts"
-      ]
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [

--- a/packages/signup-api/tsconfig.json
+++ b/packages/signup-api/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "dmno/tsconfigs/dmno-folder",
   "include": [
     "src/**/*.ts",
   ],

--- a/packages/tsconfig/tsconfig.browser.json
+++ b/packages/tsconfig/tsconfig.browser.json
@@ -18,6 +18,7 @@
       "dom.iterable"
     ],
     "skipLibCheck": true,
+    "customConditions": [ "ts-src" ]
   },
   "references": [
     { "path": "./tsconfig.node.json" }

--- a/packages/tsconfig/tsconfig.node.json
+++ b/packages/tsconfig/tsconfig.node.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
+    // "moduleResolution": "Node",
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
@@ -12,6 +13,7 @@
       "ES2023"
     ],
     "strict": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "customConditions": [ "ts-src" ],
   }
 }


### PR DESCRIPTION
see https://colinhacks.com/essays/live-types-typescript-monorepo?q=1 (and https://www.typescriptlang.org/tsconfig/#customConditions) for some details...

we are now using a custom resolution condition so that locally we rely on typscript source directly. This fixes issues in the IDE of clicking through on functions and being brought to compiled .d.ts files.

This PR also now moves all of our packages over to `"type": "module"` and changes the `.mjs` extensions back to `.js`

Unfortunately for us, the nature of our tool and how it runs means that in many cases we still need to build js files to actually run - but at least now we click through to the right ts source!