### PR TITLE
example showing dmno globals in vue templates

### DIFF
--- a/example-repo/packages/astro-web/astro.config.ts
+++ b/example-repo/packages/astro-web/astro.config.ts
@@ -20,7 +20,7 @@ import mdx from "@astrojs/mdx";
 export default defineConfig({
   integrations: [
     dmnoAstroIntegration({ redactSensitiveLogs: true }),
-    vue(),
+    vue({ appEntrypoint: '/src/vue-app-config' }),
     mdx(),
     {
       name: 'custom',

--- a/example-repo/packages/astro-web/src/components/ClientVueConfigTest.vue
+++ b/example-repo/packages/astro-web/src/components/ClientVueConfigTest.vue
@@ -1,5 +1,6 @@
 <template>
   <ul>
+    <p>{{ DMNO_PUBLIC_CONFIG.FOO }}</p>
     <li v-for="val, key in configs">
       {{key}} = {{ val }}
     </li>

--- a/example-repo/packages/astro-web/src/dmno-vue.d.ts
+++ b/example-repo/packages/astro-web/src/dmno-vue.d.ts
@@ -1,0 +1,12 @@
+/*
+Extra file required if you want to use dmno globals within vue templates
+also need to inject into `app.config.globalProperties`
+*/
+import type { DmnoGeneratedPublicConfigSchema, DmnoGeneratedConfigSchema } from "../.dmno/.typegen/schema";
+
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    DMNO_PUBLIC_CONFIG: DmnoGeneratedPublicConfigSchema;
+    DMNO_CONFIG: DmnoGeneratedConfigSchema;
+  }
+}

--- a/example-repo/packages/astro-web/src/vue-app-config.ts
+++ b/example-repo/packages/astro-web/src/vue-app-config.ts
@@ -1,0 +1,6 @@
+import type { App } from 'vue';
+
+export default (app: App) => {
+  app.config.globalProperties.DMNO_CONFIG = (globalThis as any).DMNO_CONFIG;
+  app.config.globalProperties.DMNO_PUBLIC_CONFIG = (globalThis as any).DMNO_PUBLIC_CONFIG;
+};

--- a/example-repo/packages/webapp/src/App.vue
+++ b/example-repo/packages/webapp/src/App.vue
@@ -2,8 +2,13 @@
   <div>
     <h1>Vite + DMNO!!</h1>
 
+    <p>{{ DMNO_PUBLIC_CONFIG.PUBLIC_STATIC }}</p>
+
     <ul>
-      <li v-for="_itemVal, itemKey in envVars" :key="itemKey">
+      <li
+        v-for="_itemVal, itemKey in envVars"
+        :key="itemKey"
+      >
         {{ itemKey }} =
         <template v-if="envVars[itemKey] !== undefined">
           {{ envVars[itemKey] }}
@@ -23,13 +28,13 @@ const envVars = {
   'DMNO_PUBLIC_CONFIG.CACHED_RANDOM_NUM': DMNO_PUBLIC_CONFIG.CACHED_RANDOM_NUM,
   'DMNO_PUBLIC_CONFIG.PUBLIC_STATIC': DMNO_PUBLIC_CONFIG.PUBLIC_STATIC,
   'DMNO_PUBLIC_CONFIG.PUBLIC_DYNAMIC': DMNO_PUBLIC_CONFIG.PUBLIC_DYNAMIC,
-  
+
   // error because DMNO_CONFIG doesnt exist
   // 'DMNO_CONFIG.SECRET_STATIC': DMNO_CONFIG.SECRET_STATIC,
   // error because key doesnt exist in DMNO_PUBLIC_CONFIG doesnt exist
   // 'DMNO_PUBLIC_CONFIG.SECRET_STATIC': DMNO_PUBLIC_CONFIG.SECRET_STATIC,
 
-}
+};
 
 // TODO: this should throw a runtime error (not just ts + build error)
 // console.log(DMNO_PUBLIC_CONFIG.ASDF);

--- a/example-repo/packages/webapp/src/dmno-vue.d.ts
+++ b/example-repo/packages/webapp/src/dmno-vue.d.ts
@@ -1,0 +1,8 @@
+import type { DmnoGeneratedPublicConfigSchema, DmnoGeneratedConfigSchema } from '../.dmno/.typegen/schema';
+
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    DMNO_PUBLIC_CONFIG: DmnoGeneratedPublicConfigSchema;
+    DMNO_CONFIG: DmnoGeneratedConfigSchema;
+  }
+}

--- a/example-repo/packages/webapp/src/main.ts
+++ b/example-repo/packages/webapp/src/main.ts
@@ -2,4 +2,11 @@ import { createApp } from 'vue';
 import './style.css';
 import App from './App.vue';
 
-createApp(App).mount('#app');
+const app = createApp(App);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.config.globalProperties.DMNO_CONFIG = (globalThis as any).DMNO_CONFIG;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.config.globalProperties.DMNO_PUBLIC_CONFIG = (globalThis as any).DMNO_PUBLIC_CONFIG;
+
+app.mount('#app');


### PR DESCRIPTION
By default, the `DMNO_CONFIG` and `DMNO_PUBLIC_CONFIG` globals are not accessible within the template section of a vue component. You can work around this by assigning the config value to a variable, but it feels a bit annoying...

We can make it work but requires a little work to tell TypeScript about it and to wire the globals into the vue compiler.

Examples are present for both for vanilla vue app and vue in astro.

Unfortunately, I dont think there is going to be a way to have a plugin do this, so will need to be done by the user, but it is simple enough.
