### PR TITLE
@dmno/vercel-platform

### DIFF
--- a/.changeset/strange-boxes-rule.md
+++ b/.changeset/strange-boxes-rule.md
@@ -1,0 +1,7 @@
+---
+"@dmno/netlify-platform": patch
+"@dmno/vercel-platform": patch
+"dmno": patch
+---
+
+add vercel platform, minor adjustments to core and netlify

--- a/.dmno/config.mts
+++ b/.dmno/config.mts
@@ -1,12 +1,12 @@
 import { DmnoBaseTypes, defineDmnoService, switchByNodeEnv, NodeEnvType } from 'dmno';
-import { GitDataTypes } from 'dmno/vendor-types';
+import { GitDataTypes, GithubDataTypes } from 'dmno/vendor-types';
 
 export default defineDmnoService({
   name: 'root',
   isRoot: true,
   schema: {
     GITHUB_ORG_NAME: {
-      extends: GitDataTypes.OrgName,
+      extends: GithubDataTypes.OrgName,
       required: true,
       value: 'dmno-dev',
     },

--- a/.dmno/tsconfig.json
+++ b/.dmno/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "compilerOptions": {
-    "strict": true
-  },
+  "extends": "dmno/tsconfigs/dmno-folder",
   "include": [
     "./**/*.mts",
     "./.typegen/global.d.ts"

--- a/example-repo/packages/api/.dmno/config.mts
+++ b/example-repo/packages/api/.dmno/config.mts
@@ -62,6 +62,10 @@ export default defineDmnoService({
       // value: VaultPlugin.item(),
     },
 
+    BOOL_NUM_FLAG: {
+      extends: 'boolean',
+    },
+
     A_NEW_ITEM: {
       value: "phil 1"
     }, 

--- a/example-repo/packages/api/src/routes/index.ts
+++ b/example-repo/packages/api/src/routes/index.ts
@@ -13,12 +13,13 @@ export const router = new Router<CustomAppState, CustomAppContext>();
 export type CustomRouter = Router<CustomAppState, CustomAppContext>;
 
 router.get('/', async (ctx) => {
-  // TODO: add something which checks redis and postgres connections are working
   ctx.body = {
     systemStatus: 'nope',
     envCheck: DMNO_CONFIG.API_ONLY || 'env-var-not-loaded',
     dmnoTest: DMNO_CONFIG.PORT,
     public: DMNO_PUBLIC_CONFIG.PUBLIC_EXAMPLE,
+    boolFlag_dmno: DMNO_CONFIG.BOOL_NUM_FLAG || '_empty_',
+    boolFlag_processEnv: process.env.BOOL_NUM_FLAG || '_empty_',
   };
 });
 

--- a/packages/core/src/cli/commands/run.command.ts
+++ b/packages/core/src/cli/commands/run.command.ts
@@ -64,13 +64,21 @@ program.action(async (_command, opts: {
 
   const serviceEnv = service.getEnv();
 
+  const fullInjectedEnv = {
+    ...process.env,
+  };
+  // we need to add any config items that are defined in dmno config, but we dont want to modify existing items
+  for (const key in serviceEnv) {
+    if (!Object.hasOwn(process.env, key)) {
+      const strVal = serviceEnv[key]?.toString();
+      if (strVal !== undefined) fullInjectedEnv[key] = strVal;
+    }
+  }
+  fullInjectedEnv.DMNO_INJECTED_ENV = JSON.stringify(service.getInjectedEnvJSON());
+
   commandProcess = execa(pathAwareCommand || rawCommand, commandArgsOnly, {
     stdio: 'inherit',
-    env: {
-      ...process.env,
-      ...serviceEnv,
-      DMNO_INJECTED_ENV: JSON.stringify(service.getInjectedEnvJSON()),
-    },
+    env: fullInjectedEnv,
   });
   // console.log('PARENT PID = ', process.pid);
   // console.log('CHILD PID = ', commandProcess.pid);

--- a/packages/core/src/globals-injector/injector.ts
+++ b/packages/core/src/globals-injector/injector.ts
@@ -95,12 +95,14 @@ export function injectDmnoGlobals(
     const injectedItem = injectedDmnoEnv[itemKey];
     const val = injectedItem.value;
 
-    // re-inject into process.env
+    // re-inject into process.env - only for items that dont exist
+    // TODO: this may need more logic here... for example we may want to allow types to specify how they convert to strings for re-injection
+    // TODO: we'll also need to figure out nested object paths
     if (processExists) {
       if (val === undefined || val === null) {
-        globalThis.process.env[itemKey] = '';
+        globalThis.process.env[itemKey] ||= '';
       } else {
-        globalThis.process.env[itemKey] = val.toString();
+        globalThis.process.env[itemKey] ||= val.toString();
       }
     }
 

--- a/packages/core/src/vendor-types/git.vendor-types.ts
+++ b/packages/core/src/vendor-types/git.vendor-types.ts
@@ -1,30 +1,27 @@
-import { createDmnoDataType } from 'dmno';
+import { createDmnoDataType, DmnoBaseTypes } from 'dmno';
 
-const commonTypeInfo = {
+const gitCommonTypeInfo = {
+  ui: {
+    icon: 'teenyicons:git-solid',
+  },
+};
+const githubCommonTypeInfo = {
   ui: {
     icon: 'mdi:github',
   },
 };
 
 export const GitDataTypes = {
-  OrgName: createDmnoDataType({
-    typeLabel: 'git/orgName',
-    typeDescription: 'organization name on github',
-    ...commonTypeInfo,
-  }),
-  UserName: createDmnoDataType({
-    typeLabel: 'git/username',
-    typeDescription: 'username on github',
-    ...commonTypeInfo,
-  }),
   RepoName: createDmnoDataType({
     typeLabel: 'git/repoName',
-    typeDescription: '',
+    typeDescription: 'name/slug for the repository',
+    exampleValue: 'evilcorp-api',
+    extends: DmnoBaseTypes.string({ matches: /^[\w-.]+$/, maxLength: 100 }),
     externalDocs: {
       description: 'Remote repositories (Github docs)',
       url: 'https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#about-remote-repositories',
     },
-    ...commonTypeInfo,
+    ...gitCommonTypeInfo,
   }),
   PublicRepoUrl: createDmnoDataType({
     typeLabel: 'git/repoUrl',
@@ -34,7 +31,7 @@ export const GitDataTypes = {
       description: 'Remote repositories (Github docs)',
       url: 'https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#about-remote-repositories',
     },
-    ...commonTypeInfo,
+    ...gitCommonTypeInfo,
   }),
   RemoteUrl: createDmnoDataType({
     typeLabel: 'git/remoteUrl',
@@ -44,7 +41,7 @@ export const GitDataTypes = {
       description: 'Remote repositories (Github docs)',
       url: 'https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#about-remote-repositories',
     },
-    ...commonTypeInfo,
+    ...gitCommonTypeInfo,
   }),
   BranchName: createDmnoDataType({
     typeLabel: 'git/branchName',
@@ -53,15 +50,57 @@ export const GitDataTypes = {
       description: 'Git branches (Atlassian docs)',
       url: 'https://www.atlassian.com/git/tutorials/using-branches',
     },
-    ...commonTypeInfo,
+    ...gitCommonTypeInfo,
   }),
   CommitSha: createDmnoDataType({
     typeLabel: 'git/commitSha',
     typeDescription: 'Unique id of a specific git commit - also known as “SHA” or “hash”',
+    // full SHA is 40 chars, but it is common to use shortened versions, so we may want multiple types or options
     externalDocs: {
       description: 'What are Git Hashes? (Graphite docs)',
       url: 'https://graphite.dev/guides/git-hashing',
     },
-    ...commonTypeInfo,
+    ...gitCommonTypeInfo,
   }),
+  CommitMessage: createDmnoDataType({
+    typeLabel: 'git/commitMessage',
+    typeDescription: 'Descriptive message describing the commit',
+    ...gitCommonTypeInfo,
+  }),
+
 };
+
+
+export const GithubDataTypes = {
+  OrgName: createDmnoDataType({
+    typeLabel: 'git/orgName',
+    typeDescription: 'organization name on github',
+    exampleValue: 'evilcorp',
+    extends: DmnoBaseTypes.string({ matches: /^[\w-.]+$/, maxLength: 39 }),
+    ...githubCommonTypeInfo,
+  }),
+  UserName: createDmnoDataType({
+    typeLabel: 'git/username',
+    typeDescription: 'username on github',
+    exampleValue: 'coolcoder42',
+    extends: DmnoBaseTypes.string({ matches: /^[\w-.]+$/, maxLength: 39 }),
+    ...githubCommonTypeInfo,
+  }),
+  RepoId: createDmnoDataType({
+    typeLabel: 'github/repoId',
+    typeDescription: 'Repository ID on github',
+    exampleValue: 12345,
+    extends: DmnoBaseTypes.number({ min: 1, isInt: true }),
+    ...githubCommonTypeInfo,
+  }),
+  // this doesn't seem to be a native concept to git itself, but all the providers have something similar?
+  PullRequestId: createDmnoDataType({
+    typeLabel: 'github/pullRequestId',
+    typeDescription: 'Pull request ID/number on github',
+    exampleValue: 123,
+    extends: DmnoBaseTypes.number({ min: 1, isInt: true }),
+    ...githubCommonTypeInfo,
+  }),
+
+};
+

--- a/packages/docs-site/astro.config.ts
+++ b/packages/docs-site/astro.config.ts
@@ -172,37 +172,25 @@ export default defineConfig({
         }, {
           label: 'Integrations',
           badge: 'New',
-          items: [{
-            label: 'Overview',
-            link: '/docs/integrations/overview/',
-          },
-          {
-            label: 'Astro',
-            link: '/docs/integrations/astro/',
-          },
-          {
-            label: 'Next.js',
-            link: '/docs/integrations/nextjs/',
-          }, {
-            label: 'Vite',
-            link: '/docs/integrations/vite/',
-          }, {
-            label: 'Node.js',
-            link: '/docs/integrations/node/',
-          },
-          // {
-          //   label: "Vercel",
-          //   link: "/docs/deployment/vercel/"
-          // }, {
-          //   label: "Netlify",
-          //   link: "/docs/deployment/netlify/"
-          // }, {
-          //   label: "Railway",
-          //   link: "/docs/deployment/railway/"
-          // }, {
-          //   label: "Render",
-          //   link: "/docs/deployment/render/"
-          // }
+          items: [
+            {
+              label: 'Overview',
+              link: '/docs/integrations/overview/',
+            },
+            {
+              label: 'Astro',
+              link: '/docs/integrations/astro/',
+            },
+            {
+              label: 'Next.js',
+              link: '/docs/integrations/nextjs/',
+            }, {
+              label: 'Vite',
+              link: '/docs/integrations/vite/',
+            }, {
+              label: 'Node.js',
+              link: '/docs/integrations/node/',
+            },
           ],
         }, {
           label: 'Platforms',
@@ -215,6 +203,10 @@ export default defineConfig({
             {
               label: 'Netlify',
               link: '/docs/platforms/netlify/',
+            },
+            {
+              label: 'Vercel',
+              link: '/docs/platforms/vercel/',
             },
           ],
         }, {

--- a/packages/docs-site/src/content/docs/docs/platforms/netlify.mdx
+++ b/packages/docs-site/src/content/docs/docs/platforms/netlify.mdx
@@ -107,7 +107,7 @@ Of course you _can_ still set overrides and secrets within the Netlify UI if you
 
 However, we recommend migrating all of your config to DMNO itself by using [switchBy](/docs/reference/helper-methods/#switchby) to create branching logic based on the env vars injected by Netlify.
 
-You can also use plugins - for example our [Encrypted Vault](/docs/plugins/encrypted-vault/) and [1Password](/docs/plugins/1password/) plugins - to handle sensitive config within your schema. Note that you will still set a **single environment variable** in the Netlify UI, to allow these plugins to access the rest of your secret.
+You can also use plugins - for example our [Encrypted Vault](/docs/plugins/encrypted-vault/) and [1Password](/docs/plugins/1password/) plugins - to handle sensitive config within your schema. Note that you will still set a **single environment variable** in the Netlify UI, to allow these plugins to access the rest of your secrets.
 
 For example:
 ```ts title='.dmno/config.mts'

--- a/packages/docs-site/src/content/docs/docs/platforms/overview.mdx
+++ b/packages/docs-site/src/content/docs/docs/platforms/overview.mdx
@@ -19,12 +19,20 @@ Includes:
 - Netlify-specific data types
 - Netlify build plugin
 
+### [Vercel](/docs/platforms/vercel/) 
+
+Package: `@dmno/vercel-platform`
+
+Includes:
+- Config schema of env vars injected by the Vercel platform
+- Vercel-specific data types
+
+
 ### Next up
 
 We're already working on more platform integrations, but we'd love to hear from you which platforms to tackle next!
 
 On the roadmap:
-- Vercel
 - Cloudflare
 - Fly.io
 - Heroku

--- a/packages/docs-site/src/content/docs/docs/platforms/vercel.mdx
+++ b/packages/docs-site/src/content/docs/docs/platforms/vercel.mdx
@@ -1,0 +1,105 @@
+--- 
+title: Using DMNO with Vercel
+description: Use DMNO while deploying on Vercel
+---
+
+import VercelLogo from "~icons/logos/vercel";
+
+import TabbedCode from '@/components/TabbedCode.astro';
+import BugReportLink from '@/components/BugReportLink.astro';
+
+This platform integration exposes a pre-made config schema and underlying types to interact with the env vars that Vercel injects while using their platform. You may not need this at all, but it can be useful if you are using their platform extensively and want helpful type info for their system's env vars.
+
+:::tip
+There is a Project Setting in the Vercel ui where you can turn off these env vars, so make sure that "Automatically expose System Environment Variables" is enabled.
+:::
+
+
+## Setup
+
+<TabbedCode packageName="@dmno/vercel-platform" />
+
+:::note
+If you run into any issues, feel free to <BugReportLink label='integrations/vercel'>report them to us on GitHub</BugReportLink> and try the manual installation steps below.
+:::
+
+
+## Vercel Config Schema
+
+Vercel injects a set of [system environment variables](https://vercel.com/docs/projects/environment-variables/system-environment-variables) at build and runtime that provide information about the current build or runtime environment.
+
+The `@dmno/vercel-platform` module exposes DMNO data types and a pre-made config schema object which you can use in your own schema. You can use the `pickFromSchemaObject` utility to pick only the env var keys that you need from the full list that Vercel injects. For example:
+
+```ts title='.dmno/config.mts'
+import { defineDmnoService, switchBy, pickFromSchemaObject } from 'dmno';
+import { VercelEnvSchema } from '@dmno/vercel-platform';
+
+export default defineDmnoService({
+  schema: {
+    ...pickFromSchemaObject(VercelEnvSchema, 'VERCEL_ENV', 'VERCEL_GIT_COMMIT_REF'),
+    // example of adding more specificity/control over env flag using vercel's env vars
+    APP_ENV: {
+      value: (ctx) => {
+        if (DMNO_CONFIG.VERCEL_ENV === 'production') return 'production';
+        if (DMNO_CONFIG.VERCEL_ENV === 'preview') {
+          if (DMNO_CONFIG.VERCEL_GIT_COMMIT_REF === 'staging') return 'staging';
+          else return 'preview';
+        }
+        return 'development';
+      },
+    },
+  },
+});
+```
+
+
+
+:::caution[Netlify configuration variables]
+There are also a set of [Framework specific env vars](https://vercel.com/docs/projects/environment-variables/system-environment-variables#framework-environment-variables) that vercel injects to expose their env vars to the framework. Using DMNO, you can just access those vars and mark them as non-sensitive so there is no need for them.
+:::
+
+
+## Migrating from Vercel managed config
+
+**Should I set env vars in the Vercel UI at all?**
+
+Vercel has the ability to set config vars per environment - dev/preview/prod. Of course you _can_ still set overrides and secrets within the Vercel UI if you like and rely on config values being injected that way.
+
+However, we recommend migrating all of your config to DMNO itself by using [switchBy](/docs/reference/helper-methods/#switchby) to create branching logic based on the `VERCEL_ENV` flag injected and any other logic you like. This is much more flexible and powerful, and will centralize your config management within your codebase.
+
+You can also use plugins - for example our [Encrypted Vault](/docs/plugins/encrypted-vault/) and [1Password](/docs/plugins/1password/) plugins - to handle sensitive config within your schema. Note that you will still set a **single environment variable** in the Vercel UI, to allow these plugins to access the rest of your secrets.
+
+For example:
+```ts title='.dmno/config.mts'
+import { defineDmnoService, switchBy, pickFromSchemaObject } from 'dmno';
+import { VercelEnvSchema } from '@dmno/vercel-platform';
+import {
+  EncryptedVaultDmnoPlugin, EncryptedVaultTypes,
+} from '@dmno/encrypted-vault-plugin';
+
+// you could use a single vault, but it's best practice
+// to split out prod secrets to limit access
+const DevSecretsVault = new EncryptedVaultDmnoPlugin('vault/dev', {
+  key: configPath('DMNO_VAULT_KEY_DEV'),
+  name: 'dev',
+});
+const ProdSecretsVault = new EncryptedVaultDmnoPlugin('vault/prod', {
+  key: configPath('DMNO_VAULT_KEY_PROD'),
+  name: 'prod',
+});
+
+export default defineDmnoService({
+  schema: {
+    DMNO_VAULT_KEY_DEV: { extends: EncryptedVaultTypes.encryptionKey },
+    DMNO_VAULT_KEY_PROD: { extends: EncryptedVaultTypes.encryptionKey },
+    ...pickFromSchemaObject(VercelEnvSchema, 'VERCEL_ENV'),
+    SOME_API_KEY: {
+      value: switchBy('VERCEL_ENV', {
+        _default: 'not-sensitive-dev-key',
+        staging: DevSecretsVault.item(),
+        production: ProdSecretsVault.item(),
+      }),
+    },
+  },
+});
+```

--- a/packages/docs-site/src/content/docs/docs/platforms/vercel.mdx
+++ b/packages/docs-site/src/content/docs/docs/platforms/vercel.mdx
@@ -11,7 +11,7 @@ import BugReportLink from '@/components/BugReportLink.astro';
 This platform integration exposes a pre-made config schema and underlying types to interact with the env vars that Vercel injects while using their platform. You may not need this at all, but it can be useful if you are using their platform extensively and want helpful type info for their system's env vars.
 
 :::tip
-There is a Project Setting in the Vercel ui where you can turn off these env vars, so make sure that "Automatically expose System Environment Variables" is enabled.
+There is a Project Setting in the Vercel UI where you can turn off these env vars, so make sure that "Automatically expose System Environment Variables" is enabled.
 :::
 
 
@@ -54,7 +54,7 @@ export default defineDmnoService({
 
 
 
-:::caution[Netlify configuration variables]
+:::caution[Vercel configuration variables]
 There are also a set of [Framework specific env vars](https://vercel.com/docs/projects/environment-variables/system-environment-variables#framework-environment-variables) that vercel injects to expose their env vars to the framework. Using DMNO, you can just access those vars and mark them as non-sensitive so there is no need for them.
 :::
 

--- a/packages/platforms/netlify/.eslintrc.cjs
+++ b/packages/platforms/netlify/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ["@dmno/eslint-config/base"],
+  ignorePatterns: ["tsup.config.ts"],
+  rules: {  
+  },
+};

--- a/packages/platforms/netlify/src/data-types.ts
+++ b/packages/platforms/netlify/src/data-types.ts
@@ -10,28 +10,28 @@ function getCommonTypeInfo(anchorLink: string, skipIcon = false) {
     ...!skipIcon && {
       ui: {
         icon: 'simple-icons:netlify',
-        color: '01BDBA' // netlify brand
+        color: '01BDBA', // netlify brand
       },
     },
-  }
+  };
 }
 
 export const NetlifyDataTypes = {
   // https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
-  NetlifyContext: createDmnoDataType({
+  Context: createDmnoDataType({
     typeLabel: 'netlify/context',
     extends: DmnoBaseTypes.enum({
-      'dev': {
-        description: 'local development environments run using Netlify Dev'
+      dev: {
+        description: 'local development environments run using Netlify Dev',
       },
       'branch-deploy': {
-        description: 'deploys from branches that are not the site’s main production branch.'
+        description: 'deploys from branches that are not the site\'s main production branch.',
       },
       'deploy-preview': {
-        description: 'previews built for pull/merge requests'
+        description: 'previews built for pull/merge requests',
       },
-      'production': {
-        description: 'This main site’s deployment, attached to the Git branch you set when the site is created'
+      production: {
+        description: 'This main site\'s deployment, attached to the Git branch you set when the site is created',
       },
     }),
     typeDescription: 'Netlify deploy context - can be used to detect if this is production or what type of staging/preview env it is',
@@ -41,7 +41,7 @@ export const NetlifyDataTypes = {
       url: 'https://docs.netlify.com/site-deploys/overview/#deploy-contexts',
     },
   }),
-  NetlifyBuildId: createDmnoDataType({
+  BuildId: createDmnoDataType({
     typeLabel: 'netlify/build-id',
     typeDescription: 'unique ID for the Netlify build',
     exampleValue: '5d4aeac2ccabf517d2f219b8',
@@ -49,42 +49,37 @@ export const NetlifyDataTypes = {
   }),
 
 
-  NetlifySiteName: createDmnoDataType({
+  SiteName: createDmnoDataType({
     typeLabel: 'netlify/site-name',
     typeDescription: 'name of the site - also the Netlify subdomain',
     extends: DmnoBaseTypes.string(), // TODO: what are the restrictions?
     ...getCommonTypeInfo('deploy-urls-and-metadata'),
   }),
 
-  NetlifySiteId: createDmnoDataType({
+  SiteId: createDmnoDataType({
     typeLabel: 'netlify/site-id',
     typeDescription: 'unique ID for the Netlify site',
     extends: DmnoBaseTypes.uuid(),
     ...getCommonTypeInfo('deploy-urls-and-metadata'),
   }),
-  NetlifyDeployId: createDmnoDataType({
+  DeployId: createDmnoDataType({
     typeLabel: 'netlify/deploy-id',
     typeDescription: 'unique ID for the specific Netlify deploy',
     ...getCommonTypeInfo('deploy-urls-and-metadata'),
   }),
-
-
-
-
-
-}
+};
 
 
 
 export const NetlifyEnvSchema = createVendorSchema({
   // https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
-  CONTEXT: NetlifyDataTypes.NetlifyContext,
+  CONTEXT: NetlifyDataTypes.Context,
   NETLIFY: {
     extends: 'boolean',
     description: 'can be used to check if the build is running on Netlify',
     ...getCommonTypeInfo('build-metadata'),
   },
-  BUILD_ID: NetlifyDataTypes.NetlifyBuildId,
+  BUILD_ID: NetlifyDataTypes.BuildId,
 
   // https://docs.netlify.com/configure-builds/environment-variables/#git-metadata
   REPOSITORY_URL: {
@@ -137,7 +132,7 @@ export const NetlifyEnvSchema = createVendorSchema({
     exampleValue: 'https://feature-branch--petsof.netlify.app',
     ...getCommonTypeInfo('deploy-urls-and-metadata'),
   },
-  DEPLOY_ID: NetlifyDataTypes.NetlifyDeployId,
-  SITE_NAME: NetlifyDataTypes.NetlifySiteName,
-  SITE_ID: NetlifyDataTypes.NetlifySiteId,
+  DEPLOY_ID: NetlifyDataTypes.DeployId,
+  SITE_NAME: NetlifyDataTypes.SiteName,
+  SITE_ID: NetlifyDataTypes.SiteId,
 }, { fromVendor: 'netlify' });

--- a/packages/platforms/vercel/.eslintrc.cjs
+++ b/packages/platforms/vercel/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ["@dmno/eslint-config/base"],
+  ignorePatterns: ["tsup.config.ts"],
+  rules: {  
+  },
+};

--- a/packages/platforms/vercel/package.json
+++ b/packages/platforms/vercel/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@dmno/vercel-platform",
+  "version": "0.0.0",
+  "description": "tools to use dmno with vercel",
+  "author": "dmno-dev",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dmno-dev/dmno.git",
+    "directory": "packages/platforms/vercel"
+  },
+  "bugs": "https://github.com/dmno-dev/dmno/issues",
+  "homepage": "https://dmno.dev/docs/platforms/vercel",
+  "keywords": [
+    "dmno",
+    "vercel",
+    "config",
+    "env vars",
+    "environment variables",
+    "secrets",
+    "dmno-plugin"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "ts-src": "./src/index.js",
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:ifnodist": "[ -d \"./dist\" ] && echo 'dist exists' || pnpm build",
+    "build:tarball": "turbo build && pnpm pack --pack-destination \"../../../../tmp-package-registry\"",
+    "dev": "pnpm run build --watch",
+    "lint": "eslint src --ext .ts,.cjs,.mjs",
+    "lint:fix": "pnpm run lint --fix"
+  },
+  "devDependencies": {
+    "@dmno/eslint-config": "workspace:*",
+    "@dmno/tsconfig": "workspace:*",
+    "@types/debug": "^4.1.12",
+    "@types/lodash-es": "^4.17.12",
+    "@types/node": "^20.14.11",
+    "dmno": "workspace:*",
+    "tsup": "^8.2.2",
+    "typescript": "^5.5.4"
+  },
+  "dependencies": {
+    "debug": "^4.3.5",
+    "lodash-es": "^4.17.21"
+  },
+  "peerDependencies": {
+    "dmno": "^0"
+  }
+}

--- a/packages/platforms/vercel/src/data-types.ts
+++ b/packages/platforms/vercel/src/data-types.ts
@@ -1,0 +1,173 @@
+import { DmnoBaseTypes, createDmnoDataType, createVendorSchema } from 'dmno';
+import { GitDataTypes, GithubDataTypes } from 'dmno/vendor-types';
+
+function getCommonTypeInfo(skipIcon = false) {
+  return {
+    externalDocs: {
+      url: 'https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables-overview',
+      description: 'Vercel docs',
+    },
+    ...!skipIcon && {
+      ui: {
+        icon: 'simple-icons:vercel',
+      },
+    },
+  };
+}
+
+export const VercelDataTypes = {
+  // https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+  Env: createDmnoDataType({
+    typeLabel: 'vercel/env',
+    extends: DmnoBaseTypes.enum({
+      development: {
+        description: 'local development environments running on the developer\'s computer',
+      },
+      preview: {
+        description: 'staging / preview environment for branches and pull/merge requests',
+      },
+      production: {
+        description: 'production deployment, usually linked to the site\'s primary URL',
+      },
+    }),
+    typeDescription: 'Vercel env flag',
+    ...getCommonTypeInfo(),
+    externalDocs: {
+      description: 'Vercel docs - deployment environments',
+      url: 'https://vercel.com/docs/deployments/environments',
+    },
+  }),
+
+  DeploymentId: createDmnoDataType({
+    typeLabel: 'vercel/deployment-id',
+    typeDescription: 'unique ID for the Vercel deployment',
+    extends: DmnoBaseTypes.string({ startsWith: 'dpl_' }),
+    exampleValue: 'dpl_7Gw5ZMBpQA8h9GF832KGp7nwbuh3',
+    ...getCommonTypeInfo(),
+  }),
+  EdgeNetworkRegionCode: createDmnoDataType({
+    typeLabel: 'vercel/edgeNetworkRegionCode',
+    description: 'Region code for Vercel\'s CDN/compute edge network',
+    exampleValue: 'cdg1',
+    ...getCommonTypeInfo(),
+    externalDocs: {
+      description: 'Vercel docs - Edge network regions',
+      url: 'https://vercel.com/docs/edge-network/regions',
+    },
+  }),
+};
+
+
+
+export const VercelEnvSchema = createVendorSchema({
+  VERCEL: {
+    description: 'An indicator to show that System Environment Variables have been exposed to your project\'s Deployments.',
+    extends: 'boolean',
+  },
+
+  CI: {
+    description: 'An indicator that the code is running in a Continuous Integration environment (build-time only)',
+    extends: 'boolean',
+  },
+
+  VERCEL_ENV: {
+    extends: VercelDataTypes.Env,
+  },
+
+  // TODO: add a bare "domain" data type for these, or a setting on the URL data type
+  VERCEL_URL: {
+    description: 'The domain name of the generated deployment URL (does not include the protocol - "https://") NOTE: This Variable cannot be used in conjunction with Standard Deployment Protection. See Migrating to Standard Protection.',
+    exampleValue: '*.vercel.app',
+  },
+  VERCEL_BRANCH_URL: {
+    description: 'The domain name of the generated Git branch URL. The value does not include the protocol scheme https://.',
+    exampleValue: '*-git-*.vercel.app',
+    externalDocs: {
+      description: 'Vercel docs - Generated URLS',
+      url: 'https://vercel.com/docs/deployments/generated-urls#url-with-git-branch',
+    },
+  },
+  VERCEL_PROJECT_PRODUCTION_URL: {
+    description: 'A production domain name of the project. We select the shortest production custom domain, or vercel.app domain if no custom domain is available. Note, that this is always set, even in preview deployments. This is useful to reliably generate links that point to production such as OG-image URLs. The value does not include the protocol scheme https://.',
+  },
+
+  VERCEL_REGION: {
+    description: 'The ID of the Region where the app is running. (run-time only)',
+    extends: VercelDataTypes.EdgeNetworkRegionCode,
+  },
+  VERCEL_DEPLOYMENT_ID: {
+    description: 'The unique identifier for the deployment, which can be used to implement Skew Protection',
+    extends: VercelDataTypes.DeploymentId,
+  },
+
+  VERCEL_SKEW_PROTECTION_ENABLED: {
+    description: 'When Skew Protection is enabled in Project Settings, this value is set to 1',
+    extends: 'boolean',
+  },
+
+  VERCEL_AUTOMATION_BYPASS_SECRET: {
+    description: 'The Protection Bypass for Automation value, if the secret has been generated in the project\'s Deployment Protection settings.',
+  },
+
+  VERCEL_GIT_PROVIDER: {
+    description: 'The Git Provider the deployment is triggered from',
+    exampleValue: 'github', // unclear what the full list of values is here
+  },
+
+  VERCEL_GIT_REPO_SLUG: {
+    description: 'The origin repository the deployment is triggered from.',
+    extends: GitDataTypes.RepoName,
+  },
+
+  VERCEL_GIT_REPO_OWNER: {
+    description: 'The account that owns the repository the deployment is triggered from.',
+    extends: GithubDataTypes.UserName, // TODO: should actually be some kind of "owner" which can be a user _or_ an org
+  },
+
+  VERCEL_GIT_REPO_ID: {
+    description: 'The ID of the repository the deployment is triggered from',
+    extends: GithubDataTypes.RepoId,
+    exampleValue: 117716146,
+  },
+
+  VERCEL_GIT_COMMIT_REF: {
+    description: 'The git branch of the commit the deployment was triggered by.',
+    extends: GitDataTypes.BranchName,
+    exampleValue: 'improve-about-page',
+  },
+
+  VERCEL_GIT_COMMIT_SHA: {
+    description: 'The git SHA of the commit the deployment was triggered by.',
+    extends: GitDataTypes.CommitSha,
+    exampleValue: 'fa1eade47b73733d6312d5abfad33ce9e4068081',
+  },
+
+  VERCEL_GIT_COMMIT_MESSAGE: {
+    description: 'The message attached to the commit the deployment was triggered by.',
+    extends: GitDataTypes.CommitMessage,
+    exampleValue: 'Update about page',
+  },
+
+  VERCEL_GIT_COMMIT_AUTHOR_LOGIN: {
+    // unclear if this is vercel username or git(hub) username?
+    description: 'The username attached to the author of the commit that the project was deployed by.',
+    exampleValue: 'johndoe',
+  },
+
+  VERCEL_GIT_COMMIT_AUTHOR_NAME: {
+    description: 'The name attached to the author of the commit that the project was deployed by.',
+    exampleValue: 'John Doe',
+  },
+
+  VERCEL_GIT_PREVIOUS_SHA: {
+    description: 'The git SHA of the last successful deployment for the project and branch. NOTE: This Variable is only exposed when an Ignored Build Step is provided. (build-time only)',
+    extends: GitDataTypes.CommitSha,
+    exampleValue: 'fa1eade47b73733d6312d5abfad33ce9e4068080',
+  },
+
+  VERCEL_GIT_PULL_REQUEST_ID: {
+    description: 'The pull request id the deployment was triggered by. If a deployment is created on a branch before a pull request is made, this value will be an empty string.',
+    // I think this is likely populated for all providers, even though it's not a git concept itself...
+    extends: GithubDataTypes.PullRequestId,
+  },
+}, { fromVendor: 'vercel' });

--- a/packages/platforms/vercel/src/index.ts
+++ b/packages/platforms/vercel/src/index.ts
@@ -1,0 +1,1 @@
+export * from './data-types';

--- a/packages/platforms/vercel/tsconfig.json
+++ b/packages/platforms/vercel/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@dmno/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "dist",
+    "lib": [
+      "ESNext"
+    ],
+    "rootDir": "src",
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+  ]
+}

--- a/packages/platforms/vercel/tsup.config.ts
+++ b/packages/platforms/vercel/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts', // preset + data types
+  ], 
+  dts: true,
+  sourcemap: true,
+  treeshake: true,
+  clean: true,
+  outDir: "dist",
+  format: ['esm'],
+  splitting: true,
+  keepNames: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,10 +185,10 @@ importers:
         version: 3.1.6
       '@astrojs/starlight':
         specifier: ^0.24.4
-        version: 0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
+        version: 0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
       '@astrojs/vue':
         specifier: ^4.5.0
-        version: 4.5.0(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))(rollup@4.16.4)(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
+        version: 4.5.0(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))(rollup@4.19.0)(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
       '@dmno/astro-integration':
         specifier: workspace:*
         version: link:../integrations/astro
@@ -209,10 +209,10 @@ importers:
         version: 4.1.2(vue@3.4.30(typescript@5.5.2))
       astro:
         specifier: ^4.11.1
-        version: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
+        version: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
       astro-expressive-code:
         specifier: ^0.35.3
-        version: 0.35.3(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
+        version: 0.35.3(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
       astro-google-fonts-optimizer:
         specifier: ^0.2.2
         version: 0.2.2
@@ -245,10 +245,10 @@ importers:
         version: 0.33.4
       starlight-blog:
         specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
+        version: 0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
       starlight-links-validator:
         specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
+        version: 0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -264,7 +264,7 @@ importers:
         version: 2.2.212
       netlify-cli:
         specifier: ^17.23.5
-        version: 17.23.5(@types/node@20.14.8)(picomatch@3.0.1)
+        version: 17.23.5(@types/node@20.14.12)(picomatch@3.0.1)
       typedoc:
         specifier: ^0.25.13
         version: 0.25.13(typescript@5.5.2)
@@ -469,6 +469,40 @@ importers:
         specifier: ^5.4.5
         version: 5.4.5
 
+  packages/platforms/vercel:
+    dependencies:
+      debug:
+        specifier: ^4.3.5
+        version: 4.3.5(supports-color@9.4.0)
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
+    devDependencies:
+      '@dmno/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint-config
+      '@dmno/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
+      '@types/node':
+        specifier: ^20.14.11
+        version: 20.14.12
+      dmno:
+        specifier: workspace:*
+        version: link:../../core
+      tsup:
+        specifier: ^8.2.2
+        version: 8.2.2(jiti@1.21.0)(postcss@8.4.38)(typescript@5.5.4)
+      typescript:
+        specifier: ^5.5.4
+        version: 5.5.4
+
   packages/plugins/1password:
     dependencies:
       async:
@@ -599,10 +633,10 @@ importers:
         version: link:../core
       netlify-cli:
         specifier: ^17.1.0
-        version: 17.23.0(@types/node@20.14.8)(picomatch@3.0.1)
+        version: 17.23.0(@types/node@20.14.12)(picomatch@3.0.1)
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.4.5))(typescript@5.4.5)
+        version: 8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.12)(typescript@5.4.5))(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -1157,6 +1191,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.23.0':
+    resolution: {integrity: sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.19.11':
     resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
     engines: {node: '>=12'}
@@ -1184,6 +1224,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.0':
+    resolution: {integrity: sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -1217,6 +1263,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.23.0':
+    resolution: {integrity: sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.19.11':
     resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
     engines: {node: '>=12'}
@@ -1244,6 +1296,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.0':
+    resolution: {integrity: sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -1277,6 +1335,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.19.11':
     resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
     engines: {node: '>=12'}
@@ -1304,6 +1368,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.0':
+    resolution: {integrity: sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -1337,6 +1407,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.23.0':
+    resolution: {integrity: sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.19.11':
     resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
     engines: {node: '>=12'}
@@ -1364,6 +1440,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.0':
+    resolution: {integrity: sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -1397,6 +1479,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.23.0':
+    resolution: {integrity: sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.19.11':
     resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
     engines: {node: '>=12'}
@@ -1424,6 +1512,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.0':
+    resolution: {integrity: sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -1457,6 +1551,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.23.0':
+    resolution: {integrity: sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.19.11':
     resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
     engines: {node: '>=12'}
@@ -1484,6 +1584,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.0':
+    resolution: {integrity: sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -1517,6 +1623,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.23.0':
+    resolution: {integrity: sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.19.11':
     resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
     engines: {node: '>=12'}
@@ -1544,6 +1656,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.0':
+    resolution: {integrity: sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -1577,6 +1695,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.23.0':
+    resolution: {integrity: sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.19.11':
     resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
     engines: {node: '>=12'}
@@ -1604,6 +1728,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.0':
+    resolution: {integrity: sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -1637,6 +1767,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.23.0':
+    resolution: {integrity: sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-x64@0.19.11':
     resolution: {integrity: sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==}
     engines: {node: '>=12'}
@@ -1667,6 +1803,18 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.23.0':
+    resolution: {integrity: sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.0':
+    resolution: {integrity: sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.19.11':
     resolution: {integrity: sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==}
     engines: {node: '>=12'}
@@ -1694,6 +1842,12 @@ packages:
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.0':
+    resolution: {integrity: sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -1727,6 +1881,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.23.0':
+    resolution: {integrity: sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.19.11':
     resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
     engines: {node: '>=12'}
@@ -1754,6 +1914,12 @@ packages:
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.0':
+    resolution: {integrity: sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1787,6 +1953,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.23.0':
+    resolution: {integrity: sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.19.11':
     resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
     engines: {node: '>=12'}
@@ -1814,6 +1986,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.0':
+    resolution: {integrity: sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -2712,8 +2890,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.19.0':
+    resolution: {integrity: sha512-JlPfZ/C7yn5S5p0yKk7uhHTTnFlvTgLetl2VxqE518QgyM7C9bSfFTYvB/Q/ftkq0RIPY4ySxTz+/wKJ/dXC0w==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.16.4':
     resolution: {integrity: sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.19.0':
+    resolution: {integrity: sha512-RDxUSY8D1tWYfn00DDi5myxKgOk6RvWPxhmWexcICt/MEC6yEMr4HNCu1sXXYLw8iAsg0D44NuU+qNq7zVWCrw==}
     cpu: [arm64]
     os: [android]
 
@@ -2722,8 +2910,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.19.0':
+    resolution: {integrity: sha512-emvKHL4B15x6nlNTBMtIaC9tLPRpeA5jMvRLXVbl/W9Ie7HhkrE7KQjvgS9uxgatL1HmHWDXk5TTS4IaNJxbAA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.16.4':
     resolution: {integrity: sha512-WZupV1+CdUYehaZqjaFTClJI72fjJEgTXdf4NbW69I9XyvdmztUExBtcI2yIIU6hJtYvtwS6pkTkHJz+k08mAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.19.0':
+    resolution: {integrity: sha512-fO28cWA1dC57qCd+D0rfLC4VPbh6EOJXrreBmFLWPGI9dpMlER2YwSPZzSGfq11XgcEpPukPTfEVFtw2q2nYJg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2732,8 +2930,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.19.0':
+    resolution: {integrity: sha512-2Rn36Ubxdv32NUcfm0wB1tgKqkQuft00PtM23VqLuCUR4N5jcNWDoV5iBC9jeGdgS38WK66ElncprqgMUOyomw==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.16.4':
     resolution: {integrity: sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.19.0':
+    resolution: {integrity: sha512-gJuzIVdq/X1ZA2bHeCGCISe0VWqCoNT8BvkQ+BfsixXwTOndhtLUpOg0A1Fcx/+eA6ei6rMBzlOz4JzmiDw7JQ==}
     cpu: [arm]
     os: [linux]
 
@@ -2742,8 +2950,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.19.0':
+    resolution: {integrity: sha512-0EkX2HYPkSADo9cfeGFoQ7R0/wTKb7q6DdwI4Yn/ULFE1wuRRCHybxpl2goQrx4c/yzK3I8OlgtBu4xvted0ug==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.16.4':
     resolution: {integrity: sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.19.0':
+    resolution: {integrity: sha512-GlIQRj9px52ISomIOEUq/IojLZqzkvRpdP3cLgIE1wUWaiU5Takwlzpz002q0Nxxr1y2ZgxC2obWxjr13lvxNQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2752,8 +2970,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-powerpc64le-gnu@4.19.0':
+    resolution: {integrity: sha512-N6cFJzssruDLUOKfEKeovCKiHcdwVYOT1Hs6dovDQ61+Y9n3Ek4zXvtghPPelt6U0AH4aDGnDLb83uiJMkWYzQ==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.16.4':
     resolution: {integrity: sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.19.0':
+    resolution: {integrity: sha512-2DnD3mkS2uuam/alF+I7M84koGwvn3ZVD7uG+LEWpyzo/bq8+kKnus2EVCkcvh6PlNB8QPNFOz6fWd5N8o1CYg==}
     cpu: [riscv64]
     os: [linux]
 
@@ -2762,8 +2990,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.19.0':
+    resolution: {integrity: sha512-D6pkaF7OpE7lzlTOFCB2m3Ngzu2ykw40Nka9WmKGUOTS3xcIieHe82slQlNq69sVB04ch73thKYIWz/Ian8DUA==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.16.4':
     resolution: {integrity: sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.19.0':
+    resolution: {integrity: sha512-HBndjQLP8OsdJNSxpNIN0einbDmRFg9+UQeZV1eiYupIRuZsDEoeGU43NQsS34Pp166DtwQOnpcbV/zQxM+rWA==}
     cpu: [x64]
     os: [linux]
 
@@ -2772,8 +3010,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.19.0':
+    resolution: {integrity: sha512-HxfbvfCKJe/RMYJJn0a12eiOI9OOtAUF4G6ozrFUK95BNyoJaSiBjIOHjZskTUffUrB84IPKkFG9H9nEvJGW6A==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-win32-arm64-msvc@4.16.4':
     resolution: {integrity: sha512-Ma4PwyLfOWZWayfEsNQzTDBVW8PZ6TUUN1uFTBQbF2Chv/+sjenE86lpiEwj2FiviSmSZ4Ap4MaAfl1ciF4aSA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.19.0':
+    resolution: {integrity: sha512-HxDMKIhmcguGTiP5TsLNolwBUK3nGGUEoV/BO9ldUBoMLBssvh4J0X8pf11i1fTV7WShWItB1bKAKjX4RQeYmg==}
     cpu: [arm64]
     os: [win32]
 
@@ -2782,8 +3030,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.19.0':
+    resolution: {integrity: sha512-xItlIAZZaiG/u0wooGzRsx11rokP4qyc/79LkAOdznGRAbOFc+SfEdfUOszG1odsHNgwippUJavag/+W/Etc6Q==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.16.4':
     resolution: {integrity: sha512-YunpoOAyGLDseanENHmbFvQSfVL5BxW3k7hhy0eN4rb3gS/ct75dVD0EXOWIqFT/nE8XYW6LP6vz6ctKRi0k9A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.19.0':
+    resolution: {integrity: sha512-xNo5fV5ycvCCKqiZcpB65VMR11NJB+StnxHz20jdqRAktfdfzhgjTiJ2doTDQE/7dqGaV5I7ZGqKpgph6lCIag==}
     cpu: [x64]
     os: [win32]
 
@@ -2947,6 +3205,9 @@ packages:
 
   '@types/node@20.12.7':
     resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
+
+  '@types/node@20.14.12':
+    resolution: {integrity: sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==}
 
   '@types/node@20.14.8':
     resolution: {integrity: sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==}
@@ -3865,6 +4126,12 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.17'
+
+  bundle-require@5.0.0:
+    resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -4817,6 +5084,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.23.0:
+    resolution: {integrity: sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.1.2:
@@ -7607,6 +7879,9 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
+  picocolors@1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -7673,6 +7948,24 @@ packages:
       postcss:
         optional: true
       ts-node:
+        optional: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   postcss-nested@6.0.1:
@@ -8158,6 +8451,11 @@ packages:
 
   rollup@4.16.4:
     resolution: {integrity: sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.19.0:
+    resolution: {integrity: sha512-5r7EYSQIowHsK4eTZ0Y81qpZuJz+MUuYeqmmYmRMl1nwhdmbiYqt5jwzf6u7wyOzJgYqtCRMtVRKOtHANBz7rA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -8988,6 +9286,25 @@ packages:
       typescript:
         optional: true
 
+  tsup@8.2.2:
+    resolution: {integrity: sha512-MufIuzdSt6HYPOeOtjUXLR4rqRJySi6XsRNZdwvjC2XR+xghsu2L3vSmYmX+k4S1mO6j0OlUEyVQ3Fc0H66XcA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -9136,6 +9453,11 @@ packages:
 
   typescript@5.5.2:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10009,12 +10331,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@3.1.2(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))':
+  '@astrojs/mdx@3.1.2(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))':
     dependencies:
       '@astrojs/markdown-remark': 5.1.1
       '@mdx-js/mdx': 3.0.1
       acorn: 8.12.0
-      astro: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
+      astro: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
       es-module-lexer: 1.5.4
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -10050,15 +10372,15 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))':
+  '@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))':
     dependencies:
-      '@astrojs/mdx': 3.1.2(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
+      '@astrojs/mdx': 3.1.2(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
       '@astrojs/sitemap': 3.1.6
       '@pagefind/default-ui': 1.1.0
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      astro: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
-      astro-expressive-code: 0.35.3(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
+      astro: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
+      astro-expressive-code: 0.35.3(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.1
       hast-util-select: 6.0.2
@@ -10088,13 +10410,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vue@4.5.0(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))(rollup@4.16.4)(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
+  '@astrojs/vue@4.5.0(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))(rollup@4.19.0)(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
     dependencies:
-      '@vitejs/plugin-vue': 5.0.5(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
-      '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
+      '@vitejs/plugin-vue': 5.0.5(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
+      '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
       '@vue/compiler-sfc': 3.4.30
-      astro: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
-      vite-plugin-vue-devtools: 7.3.4(rollup@4.16.4)(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
+      astro: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
+      vite-plugin-vue-devtools: 7.3.4(rollup@4.19.0)(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
       vue: 3.4.30(typescript@5.5.2)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -10697,6 +11019,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.23.0':
+    optional: true
+
   '@esbuild/android-arm64@0.19.11':
     optional: true
 
@@ -10710,6 +11035,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.0':
     optional: true
 
   '@esbuild/android-arm@0.19.11':
@@ -10727,6 +11055,9 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.23.0':
+    optional: true
+
   '@esbuild/android-x64@0.19.11':
     optional: true
 
@@ -10740,6 +11071,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.23.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.11':
@@ -10757,6 +11091,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.23.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.19.11':
     optional: true
 
@@ -10770,6 +11107,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.11':
@@ -10787,6 +11127,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.23.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.19.11':
     optional: true
 
@@ -10800,6 +11143,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.0':
     optional: true
 
   '@esbuild/linux-arm64@0.19.11':
@@ -10817,6 +11163,9 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.23.0':
+    optional: true
+
   '@esbuild/linux-arm@0.19.11':
     optional: true
 
@@ -10830,6 +11179,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.0':
     optional: true
 
   '@esbuild/linux-ia32@0.19.11':
@@ -10847,6 +11199,9 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.23.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.19.11':
     optional: true
 
@@ -10860,6 +11215,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.11':
@@ -10877,6 +11235,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.23.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.19.11':
     optional: true
 
@@ -10890,6 +11251,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.11':
@@ -10907,6 +11271,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.23.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.19.11':
     optional: true
 
@@ -10920,6 +11287,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.23.0':
     optional: true
 
   '@esbuild/linux-x64@0.19.11':
@@ -10937,6 +11307,9 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.23.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.19.11':
     optional: true
 
@@ -10950,6 +11323,12 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.23.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.11':
@@ -10967,6 +11346,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.23.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.19.11':
     optional: true
 
@@ -10980,6 +11362,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.23.0':
     optional: true
 
   '@esbuild/win32-arm64@0.19.11':
@@ -10997,6 +11382,9 @@ snapshots:
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.23.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.19.11':
     optional: true
 
@@ -11012,6 +11400,9 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.23.0':
+    optional: true
+
   '@esbuild/win32-x64@0.19.11':
     optional: true
 
@@ -11025,6 +11416,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -11261,7 +11655,7 @@ snapshots:
       '@inquirer/figures': 1.0.1
       '@inquirer/type': 1.3.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -11369,7 +11763,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -11504,7 +11898,7 @@ snapshots:
       yaml: 2.4.1
       yargs: 17.7.2
 
-  '@netlify/build@29.41.0(@opentelemetry/api@1.8.0)(@types/node@20.14.8)(picomatch@3.0.1)':
+  '@netlify/build@29.41.0(@opentelemetry/api@1.8.0)(@types/node@20.14.12)(picomatch@3.0.1)':
     dependencies:
       '@bugsnag/js': 7.23.0
       '@netlify/blobs': 7.3.0
@@ -11561,8 +11955,8 @@ snapshots:
       strip-ansi: 7.1.0
       supports-color: 9.4.0
       terminal-link: 3.0.0
-      ts-node: 10.9.2(@types/node@20.14.8)(typescript@5.5.2)
-      typescript: 5.5.2
+      ts-node: 10.9.2(@types/node@20.14.12)(typescript@5.5.4)
+      typescript: 5.5.4
       uuid: 9.0.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -11572,7 +11966,7 @@ snapshots:
       - encoding
       - picomatch
 
-  '@netlify/build@29.41.5(@opentelemetry/api@1.8.0)(@types/node@20.14.8)(picomatch@3.0.1)':
+  '@netlify/build@29.41.5(@opentelemetry/api@1.8.0)(@types/node@20.14.12)(picomatch@3.0.1)':
     dependencies:
       '@bugsnag/js': 7.23.0
       '@netlify/blobs': 7.3.0
@@ -11629,8 +12023,8 @@ snapshots:
       strip-ansi: 7.1.0
       supports-color: 9.4.0
       terminal-link: 3.0.0
-      ts-node: 10.9.2(@types/node@20.14.8)(typescript@5.5.2)
-      typescript: 5.5.2
+      ts-node: 10.9.2(@types/node@20.14.12)(typescript@5.5.4)
+      typescript: 5.5.4
       uuid: 9.0.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -12341,60 +12735,108 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.0(rollup@4.16.4)':
+  '@rollup/pluginutils@5.1.0(rollup@4.19.0)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.16.4
+      rollup: 4.19.0
 
   '@rollup/rollup-android-arm-eabi@4.16.4':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.19.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.16.4':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.19.0':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.16.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.19.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.16.4':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.19.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.19.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.16.4':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.19.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.19.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.16.4':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.19.0':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.19.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.16.4':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.19.0':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.19.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.16.4':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.19.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.19.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.16.4':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.19.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.16.4':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.19.0':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.16.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.19.0':
     optional: true
 
   '@shikijs/core@1.3.0': {}
@@ -12466,7 +12908,7 @@ snapshots:
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
 
   '@types/cookie@0.6.0': {}
 
@@ -12494,7 +12936,7 @@ snapshots:
 
   '@types/http-proxy@1.17.14':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
 
   '@types/is-empty@1.2.3': {}
 
@@ -12538,7 +12980,7 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
 
   '@types/nlcst@2.0.3':
     dependencies:
@@ -12560,6 +13002,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.14.12':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.14.8':
     dependencies:
       undici-types: 5.26.5
@@ -12570,7 +13016,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
 
   '@types/semver@7.5.8': {}
 
@@ -12578,7 +13024,7 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
       minipass: 4.2.8
 
   '@types/tinycolor2@1.4.6': {}
@@ -12591,7 +13037,7 @@ snapshots:
 
   '@types/unzip-stream@0.3.4':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -12607,7 +13053,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
     optional: true
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
@@ -12716,7 +13162,7 @@ snapshots:
 
   '@typescript-eslint/types@7.7.1': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@9.4.0)(typescript@5.5.2)':
+  '@typescript-eslint/typescript-estree@5.62.0(supports-color@9.4.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -12724,9 +13170,9 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
-      tsutils: 3.21.0(typescript@5.5.2)
+      tsutils: 3.21.0(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.5.2
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12873,19 +13319,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.0.0(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
+  '@vitejs/plugin-vue-jsx@4.0.0(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.24.7)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.7)
-      vite: 5.3.1(@types/node@20.14.8)(less@4.2.0)
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
       vue: 3.4.30(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.5(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
+  '@vitejs/plugin-vue@5.0.5(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
     dependencies:
-      vite: 5.3.1(@types/node@20.14.8)(less@4.2.0)
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
       vue: 3.4.30(typescript@5.5.2)
 
   '@vitest/expect@1.6.0':
@@ -13066,14 +13512,14 @@ snapshots:
       '@vue/compiler-dom': 3.4.30
       '@vue/shared': 3.4.30
 
-  '@vue/devtools-core@7.3.4(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
+  '@vue/devtools-core@7.3.4(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))':
     dependencies:
       '@vue/devtools-kit': 7.3.4
       '@vue/devtools-shared': 7.3.4
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))
+      vite-hot-client: 0.2.3(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))
       vue: 3.4.30(typescript@5.5.2)
     transitivePeerDependencies:
       - vite
@@ -13511,9 +13957,9 @@ snapshots:
       - supports-color
       - typescript
 
-  astro-expressive-code@0.35.3(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)):
+  astro-expressive-code@0.35.3(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)):
     dependencies:
-      astro: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
+      astro: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
       rehype-expressive-code: 0.35.3
 
   astro-google-fonts-optimizer@0.2.2: {}
@@ -13546,6 +13992,84 @@ snapshots:
       minimatch: 9.0.4
       sitemap: 7.1.1
       zod: 3.23.4
+
+  astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2):
+    dependencies:
+      '@astrojs/compiler': 2.8.1
+      '@astrojs/internal-helpers': 0.4.1
+      '@astrojs/markdown-remark': 5.1.1
+      '@astrojs/telemetry': 3.1.0
+      '@babel/core': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+      '@types/babel__core': 7.20.5
+      '@types/cookie': 0.6.0
+      acorn: 8.12.0
+      aria-query: 5.3.0
+      axobject-query: 4.0.0
+      boxen: 7.1.1
+      chokidar: 3.6.0
+      ci-info: 4.0.0
+      clsx: 2.1.1
+      common-ancestor-path: 1.0.1
+      cookie: 0.6.0
+      cssesc: 3.0.0
+      debug: 4.3.5(supports-color@9.4.0)
+      deterministic-object-hash: 2.0.2
+      devalue: 5.0.0
+      diff: 5.2.0
+      dlv: 1.1.3
+      dset: 3.1.3
+      es-module-lexer: 1.5.4
+      esbuild: 0.21.5
+      estree-walker: 3.0.3
+      execa: 8.0.1
+      fast-glob: 3.3.2
+      flattie: 1.1.1
+      github-slugger: 2.0.0
+      gray-matter: 4.0.3
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.1.1
+      js-yaml: 4.1.0
+      kleur: 4.1.5
+      magic-string: 0.30.10
+      mrmime: 2.0.0
+      ora: 8.0.1
+      p-limit: 5.0.0
+      p-queue: 8.0.1
+      path-to-regexp: 6.2.2
+      preferred-pm: 3.1.3
+      prompts: 2.4.2
+      rehype: 13.0.1
+      resolve: 1.22.8
+      semver: 7.6.2
+      shiki: 1.9.1
+      string-width: 7.1.0
+      strip-ansi: 7.1.0
+      tsconfck: 3.1.0(typescript@5.5.2)
+      unist-util-visit: 5.0.0
+      vfile: 6.0.1
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
+      vitefu: 0.2.5(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))
+      which-pm: 2.2.0
+      yargs-parser: 21.1.1
+      zod: 3.23.8
+      zod-to-json-schema: 3.23.1(zod@3.23.8)
+    optionalDependencies:
+      sharp: 0.33.4
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
 
   astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2):
     dependencies:
@@ -13883,6 +14407,11 @@ snapshots:
   bundle-require@4.0.3(esbuild@0.21.5):
     dependencies:
       esbuild: 0.21.5
+      load-tsconfig: 0.2.5
+
+  bundle-require@5.0.0(esbuild@0.23.0):
+    dependencies:
+      esbuild: 0.23.0
       load-tsconfig: 0.2.5
 
   busboy@1.6.0:
@@ -14609,10 +15138,10 @@ snapshots:
 
   detective-typescript@11.2.0(supports-color@9.4.0):
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.4.0)(typescript@5.5.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@9.4.0)(typescript@5.5.4)
       ast-module-types: 5.0.0
       node-source-walk: 6.0.2
-      typescript: 5.5.2
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -14964,6 +15493,33 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.23.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.0
+      '@esbuild/android-arm': 0.23.0
+      '@esbuild/android-arm64': 0.23.0
+      '@esbuild/android-x64': 0.23.0
+      '@esbuild/darwin-arm64': 0.23.0
+      '@esbuild/darwin-x64': 0.23.0
+      '@esbuild/freebsd-arm64': 0.23.0
+      '@esbuild/freebsd-x64': 0.23.0
+      '@esbuild/linux-arm': 0.23.0
+      '@esbuild/linux-arm64': 0.23.0
+      '@esbuild/linux-ia32': 0.23.0
+      '@esbuild/linux-loong64': 0.23.0
+      '@esbuild/linux-mips64el': 0.23.0
+      '@esbuild/linux-ppc64': 0.23.0
+      '@esbuild/linux-riscv64': 0.23.0
+      '@esbuild/linux-s390x': 0.23.0
+      '@esbuild/linux-x64': 0.23.0
+      '@esbuild/netbsd-x64': 0.23.0
+      '@esbuild/openbsd-arm64': 0.23.0
+      '@esbuild/openbsd-x64': 0.23.0
+      '@esbuild/sunos-x64': 0.23.0
+      '@esbuild/win32-arm64': 0.23.0
+      '@esbuild/win32-ia32': 0.23.0
+      '@esbuild/win32-x64': 0.23.0
 
   escalade@3.1.2: {}
 
@@ -17873,12 +18429,12 @@ snapshots:
 
   nested-error-stacks@2.1.1: {}
 
-  netlify-cli@17.23.0(@types/node@20.14.8)(picomatch@3.0.1):
+  netlify-cli@17.23.0(@types/node@20.14.12)(picomatch@3.0.1):
     dependencies:
       '@bugsnag/js': 7.22.7
       '@fastify/static': 6.12.0
       '@netlify/blobs': 7.3.0
-      '@netlify/build': 29.41.0(@opentelemetry/api@1.8.0)(@types/node@20.14.8)(picomatch@3.0.1)
+      '@netlify/build': 29.41.0(@opentelemetry/api@1.8.0)(@types/node@20.14.12)(picomatch@3.0.1)
       '@netlify/build-info': 7.13.2
       '@netlify/config': 20.12.2
       '@netlify/edge-bundler': 12.0.0(supports-color@9.4.0)
@@ -18012,12 +18568,12 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
-  netlify-cli@17.23.5(@types/node@20.14.8)(picomatch@3.0.1):
+  netlify-cli@17.23.5(@types/node@20.14.12)(picomatch@3.0.1):
     dependencies:
       '@bugsnag/js': 7.23.0
       '@fastify/static': 6.12.0
       '@netlify/blobs': 7.3.0
-      '@netlify/build': 29.41.5(@opentelemetry/api@1.8.0)(@types/node@20.14.8)(picomatch@3.0.1)
+      '@netlify/build': 29.41.5(@opentelemetry/api@1.8.0)(@types/node@20.14.12)(picomatch@3.0.1)
       '@netlify/build-info': 7.13.2
       '@netlify/config': 20.12.5
       '@netlify/edge-bundler': 12.0.1(supports-color@9.4.0)
@@ -18727,6 +19283,8 @@ snapshots:
 
   picocolors@1.0.0: {}
 
+  picocolors@1.0.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@3.0.1: {}
@@ -18808,13 +19366,13 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.12)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.1
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(@types/node@20.14.8)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@20.14.12)(typescript@5.4.5)
 
   postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.5.2)):
     dependencies:
@@ -18823,6 +19381,13 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.2(@types/node@20.14.8)(typescript@5.5.2)
+
+  postcss-load-config@6.0.1(jiti@1.21.0)(postcss@8.4.38):
+    dependencies:
+      lilconfig: 3.1.1
+    optionalDependencies:
+      jiti: 1.21.0
+      postcss: 8.4.38
 
   postcss-nested@6.0.1(postcss@8.4.38):
     dependencies:
@@ -19455,6 +20020,28 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.16.4
       fsevents: 2.3.3
 
+  rollup@4.19.0:
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.19.0
+      '@rollup/rollup-android-arm64': 4.19.0
+      '@rollup/rollup-darwin-arm64': 4.19.0
+      '@rollup/rollup-darwin-x64': 4.19.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.19.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.19.0
+      '@rollup/rollup-linux-arm64-gnu': 4.19.0
+      '@rollup/rollup-linux-arm64-musl': 4.19.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.19.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.19.0
+      '@rollup/rollup-linux-s390x-gnu': 4.19.0
+      '@rollup/rollup-linux-x64-gnu': 4.19.0
+      '@rollup/rollup-linux-x64-musl': 4.19.0
+      '@rollup/rollup-win32-arm64-msvc': 4.19.0
+      '@rollup/rollup-win32-ia32-msvc': 4.19.0
+      '@rollup/rollup-win32-x64-msvc': 4.19.0
+      fsevents: 2.3.3
+
   run-applescript@7.0.0: {}
 
   run-async@2.4.1: {}
@@ -19840,21 +20427,21 @@ snapshots:
 
   stackframe@1.3.4: {}
 
-  starlight-blog@0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)):
+  starlight-blog@0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)):
     dependencies:
       '@astrojs/rss': 4.0.5
-      '@astrojs/starlight': 0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
-      astro: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
+      '@astrojs/starlight': 0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
+      astro: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
       astro-remote: 0.3.2
       github-slugger: 2.0.0
       marked: 12.0.2
       marked-plaintify: 1.0.1(marked@12.0.2)
       ultrahtml: 1.5.3
 
-  starlight-links-validator@0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)):
+  starlight-links-validator@0.9.0(@astrojs/starlight@0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)))(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)):
     dependencies:
-      '@astrojs/starlight': 0.24.4(astro@4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2))
-      astro: 4.11.1(@types/node@20.14.8)(less@4.2.0)(typescript@5.5.2)
+      '@astrojs/starlight': 0.24.4(astro@4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2))
+      astro: 4.11.1(@types/node@20.14.12)(less@4.2.0)(typescript@5.5.2)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.1
       hast-util-has-property: 3.0.0
@@ -20329,14 +20916,14 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@20.14.8)(typescript@5.4.5):
+  ts-node@10.9.2(@types/node@20.14.12)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
       acorn: 8.12.0
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -20347,6 +20934,24 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
+
+  ts-node@10.9.2(@types/node@20.14.12)(typescript@5.5.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.12
+      acorn: 8.12.0
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   ts-node@10.9.2(@types/node@20.14.8)(typescript@5.5.2):
     dependencies:
@@ -20365,6 +20970,7 @@ snapshots:
       typescript: 5.5.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   tsconfck@3.1.0(typescript@5.5.2):
     optionalDependencies:
@@ -20386,7 +20992,7 @@ snapshots:
       bundle-require: 4.0.3(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.5(supports-color@9.4.0)
+      debug: 4.3.4
       esbuild: 0.19.12
       execa: 5.1.1
       globby: 11.1.0
@@ -20427,17 +21033,17 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.4.5))(typescript@5.4.5):
+  tsup@8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.12)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       bundle-require: 4.0.3(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.5(supports-color@9.4.0)
+      debug: 4.3.4
       esbuild: 0.19.12
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.12)(typescript@5.4.5))
       resolve-from: 5.0.0
       rollup: 4.16.4
       source-map: 0.8.0-beta.0
@@ -20473,10 +21079,37 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsutils@3.21.0(typescript@5.5.2):
+  tsup@8.2.2(jiti@1.21.0)(postcss@8.4.38)(typescript@5.5.4):
+    dependencies:
+      bundle-require: 5.0.0(esbuild@0.23.0)
+      cac: 6.7.14
+      chokidar: 3.6.0
+      consola: 3.2.3
+      debug: 4.3.5(supports-color@9.4.0)
+      esbuild: 0.23.0
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      picocolors: 1.0.1
+      postcss-load-config: 6.0.1(jiti@1.21.0)(postcss@8.4.38)
+      resolve-from: 5.0.0
+      rollup: 4.19.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.4.38
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsutils@3.21.0(typescript@5.5.4):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.5.2
+      typescript: 5.5.4
 
   tty-table@4.2.3:
     dependencies:
@@ -20615,6 +21248,8 @@ snapshots:
 
   typescript@5.5.2: {}
 
+  typescript@5.5.4: {}
+
   ufo@1.5.3: {}
 
   uid-safe@2.1.5:
@@ -20656,7 +21291,7 @@ snapshots:
       '@types/concat-stream': 2.0.3
       '@types/debug': 4.1.12
       '@types/is-empty': 1.2.3
-      '@types/node': 20.14.8
+      '@types/node': 20.14.12
       '@types/unist': 3.0.2
       concat-stream: 2.0.0
       debug: 4.3.5(supports-color@9.4.0)
@@ -20942,9 +21577,9 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-hot-client@0.2.3(vite@5.3.1(@types/node@20.14.8)(less@4.2.0)):
+  vite-hot-client@0.2.3(vite@5.3.1(@types/node@20.14.12)(less@4.2.0)):
     dependencies:
-      vite: 5.3.1(@types/node@20.14.8)(less@4.2.0)
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
 
   vite-node@1.5.2(@types/node@20.12.7)(less@4.2.0):
     dependencies:
@@ -20980,10 +21615,10 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.8.4(rollup@4.16.4)(vite@5.3.1(@types/node@20.14.8)(less@4.2.0)):
+  vite-plugin-inspect@0.8.4(rollup@4.19.0)(vite@5.3.1(@types/node@20.14.12)(less@4.2.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
       debug: 4.3.5(supports-color@9.4.0)
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0
@@ -20991,28 +21626,28 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.3.1(@types/node@20.14.8)(less@4.2.0)
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vue-devtools@7.3.4(rollup@4.16.4)(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2)):
+  vite-plugin-vue-devtools@7.3.4(rollup@4.19.0)(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2)):
     dependencies:
-      '@vue/devtools-core': 7.3.4(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
+      '@vue/devtools-core': 7.3.4(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))(vue@3.4.30(typescript@5.5.2))
       '@vue/devtools-kit': 7.3.4
       '@vue/devtools-shared': 7.3.4
       execa: 8.0.1
       sirv: 2.0.4
-      vite: 5.3.1(@types/node@20.14.8)(less@4.2.0)
-      vite-plugin-inspect: 0.8.4(rollup@4.16.4)(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))
-      vite-plugin-vue-inspector: 5.1.2(vite@5.3.1(@types/node@20.14.8)(less@4.2.0))
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
+      vite-plugin-inspect: 0.8.4(rollup@4.19.0)(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))
+      vite-plugin-vue-inspector: 5.1.2(vite@5.3.1(@types/node@20.14.12)(less@4.2.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.1.2(vite@5.3.1(@types/node@20.14.8)(less@4.2.0)):
+  vite-plugin-vue-inspector@5.1.2(vite@5.3.1(@types/node@20.14.12)(less@4.2.0)):
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.7)
@@ -21023,7 +21658,7 @@ snapshots:
       '@vue/compiler-dom': 3.4.30
       kolorist: 1.8.0
       magic-string: 0.30.10
-      vite: 5.3.1(@types/node@20.14.8)(less@4.2.0)
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21037,6 +21672,16 @@ snapshots:
       fsevents: 2.3.3
       less: 4.2.0
 
+  vite@5.3.1(@types/node@20.14.12)(less@4.2.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.38
+      rollup: 4.16.4
+    optionalDependencies:
+      '@types/node': 20.14.12
+      fsevents: 2.3.3
+      less: 4.2.0
+
   vite@5.3.1(@types/node@20.14.8)(less@4.2.0):
     dependencies:
       esbuild: 0.21.5
@@ -21046,6 +21691,10 @@ snapshots:
       '@types/node': 20.14.8
       fsevents: 2.3.3
       less: 4.2.0
+
+  vitefu@0.2.5(vite@5.3.1(@types/node@20.14.12)(less@4.2.0)):
+    optionalDependencies:
+      vite: 5.3.1(@types/node@20.14.12)(less@4.2.0)
 
   vitefu@0.2.5(vite@5.3.1(@types/node@20.14.8)(less@4.2.0)):
     optionalDependencies:


### PR DESCRIPTION
adding a vercel platform module. This just exposes a schema of vercel-injected env vars, and will not be needed most of the time.

also made a few adjustments along the way
- standardizing on naming convention for vendor types (ex: `VendorDataTypes.Thing` (rather than `VendorDataTypes.VendorThing`
- make sure we don't overwrite original `process.env` values, just inject new ones. This is important for things like boolean vals injected as `SOME_FLAG=1` so that existing code checking for `process.env.SOME_FLAG === '1'` doesn't break