### PR TITLE
More flexible workspace detection

### DIFF
--- a/.changeset/eleven-cherries-hang.md
+++ b/.changeset/eleven-cherries-hang.md
@@ -1,0 +1,5 @@
+---
+"dmno": patch
+---
+
+more flexible workspace project detection

--- a/example-repo/.dmno/dmno-workspace.yaml
+++ b/example-repo/.dmno/dmno-workspace.yaml
@@ -1,0 +1,3 @@
+projects:
+  # all packages in direct subdirs of packages/
+  - 'packages/*'

--- a/packages/core/src/cli/lib/selection-helpers.ts
+++ b/packages/core/src/cli/lib/selection-helpers.ts
@@ -107,7 +107,7 @@ export function addServiceSelection(program: Command, opts?: {
       // handle picking from a menu, default selection will be based on CWD
       // this pre-selects the menu, but does not continue automatically
       // NOTE - `pnpm --filter=child-package exec dmno` changes the cwd correctly
-      if (explicitMenuOptIn || !opts?.disableMenuSelect) {
+      if (!thisCommand.opts().silent && (explicitMenuOptIn || !opts?.disableMenuSelect)) {
         // order our services by folder depth (descending)
         // so we can look for whiuch folder the user is in
         const servicesOrderedByDirDepth = _.orderBy(workspace.allServices, (s) => s.path.split('/').length, ['desc']);

--- a/packages/core/src/config-loader/config-server.ts
+++ b/packages/core/src/config-loader/config-server.ts
@@ -1,12 +1,13 @@
 import ipc from 'node-ipc';
 import mitt, { Handler } from 'mitt';
 import Debug from 'debug';
-import { DeferredPromise, createDeferredPromise } from '@dmno/ts-lib';
+import { createDeferredPromise } from '@dmno/ts-lib';
 
 import kleur from 'kleur';
 import { ConfigLoader } from './config-loader';
 import { createDebugTimer } from '../cli/lib/debug-timer';
 import { ConfigLoaderRequestMap } from './ipc-requests';
+import { detectJsPackageManager } from '../lib/detect-package-manager';
 
 
 const debug = Debug('dmno');
@@ -153,16 +154,16 @@ export class ConfigServer {
       // if selecting by package name, we'll first make sure the package is valid and initialized
       // this may need to move somewher else / happen earlier when setting up `dmno dev`?
       if (payload.packageName) {
-        const packageManager = this.configLoader.workspaceInfo.packageManager;
         const selectedPackageInfo = this.configLoader.workspacePackagesData.find((p) => p.name === payload.packageName);
         if (selectedPackageInfo) {
           if (!selectedPackageInfo.dmnoFolder) {
+            const packageManager = detectJsPackageManager();
             console.log(`\n🚨 Package ${selectedPackageInfo.name} has not yet been initialized as a DMNO service`);
             console.log();
             // TODO we'll want a helper to get commands for the current package manager (pnpm exec dmno)
             // could also detect current directory and skip the cd
             console.log('Please run the following command to get it set up:');
-            console.log(kleur.cyan(` cd ${selectedPackageInfo.path} && ${packageManager} exec dmno init`));
+            console.log(kleur.cyan(` cd ${selectedPackageInfo.path} && ${packageManager.exec} dmno init`));
             console.log();
             process.exit(1);
           }

--- a/packages/core/src/lib/detect-package-manager.ts
+++ b/packages/core/src/lib/detect-package-manager.ts
@@ -94,11 +94,11 @@ export async function detectPackageManager() {
     }
     // show some hopefully useful error messaging if we hit the root folder without finding anything
     if (cwd === '') {
-      console.log(kleur.red('Unable to find detect your package manager and workspace root!'));
+      console.log(kleur.red('Unable to detect your package manager and workspace root!'));
       if (possibleRootPackage) {
         console.log(`But it looks like your workspace root might be ${kleur.green().italic(possibleRootPackage)}`);
       }
-      console.log('We look for lock files (ex: package-lock.json) so you may just need to run a dependency install (ie `npm install`)');
+      console.log('We look for lock files (ex: package-lock.json) so you may just need to run a dependency install, for example `npm install`');
       process.exit(1);
     }
   }

--- a/packages/core/src/lib/detect-package-manager.ts
+++ b/packages/core/src/lib/detect-package-manager.ts
@@ -1,165 +1,97 @@
-import fs from 'fs';
 import path from 'path';
 import kleur from 'kleur';
-import { asyncMapValues } from './async-utils';
+import { pathExistsSync } from './fs-utils';
 
+export type JsPackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'deno';
 
-// TODO: move PACKAGE_MANAGER_RELEVANT_FILES into this
-export const PACKAGE_MANAGERS_META = {
+type JsPackageManagerMeta = {
+  name: JsPackageManager;
+  lockfile: string;
+  add: string;
+  exec: string;
+  dlx: string;
+};
+
+export const JS_PACKAGE_MANAGERS: Record<JsPackageManager, JsPackageManagerMeta> = Object.freeze({
   npm: {
-    exec: 'npm exec',
+    name: 'npm',
+    lockfile: 'package-lock.json',
+    add: 'npm install', // add also works
+    exec: 'npm exec --',
     dlx: 'npx',
   },
-  yarn: {
-    exec: 'yarn exec',
-    dlx: 'yarn dlx',
-  },
   pnpm: {
+    name: 'pnpm',
+    lockfile: 'pnpm-lock.yaml',
+    add: 'pnpm add',
     exec: 'pnpm exec',
     dlx: 'pnpm dlx',
   },
+  yarn: {
+    name: 'yarn',
+    lockfile: 'yarn.lock',
+    add: 'yarn add',
+    exec: 'yarn exec --',
+    dlx: 'yarn dlx',
+  },
   bun: {
+    name: 'bun',
+    lockfile: 'bun.lockb',
+    add: 'bun add',
     exec: 'bun run',
     dlx: 'bunx',
   },
-  moon: {
-    // TODO: fix this... we'll need to track the fact that the user is using moon and a package manager
-    exec: 'npm exec',
-    dlx: 'npx',
+  deno: { //! deno not fully supported yet
+    name: 'deno',
+    lockfile: 'deno.lock',
+    add: 'deno add',
+    // TODO: don't think these are quite right...
+    exec: 'deno run',
+    dlx: 'deno run',
   },
-} as const;
-export type PackageManager = keyof typeof PACKAGE_MANAGERS_META;
+});
 
-
-
-export async function pathExists(p: string) {
-  try {
-    await fs.promises.access(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-function pathExistsSync(p:string) {
-  try {
-    fs.accessSync(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-// TODO: nx and lerna support? (lerna.json has packages array)
-// TODO: deno?
-const PACKAGE_MANAGER_RELEVANT_FILES = {
-  packageJson: 'package.json',
-  yarnLock: 'yarn.lock',
-  npmLock: 'package-lock.json',
-  pnpmLock: 'pnpm-lock.yaml',
-  pnpmWorkspace: 'pnpm-workspace.yaml',
-  bunLock: 'bun.lockb',
-  moonWorkspace: '.moon/workspace.yml',
-};
-
-// SEE SYNC VERSION BELOW - UPDATE BOTH IF ANY CHANGES ARE MADE!
-export async function detectPackageManager() {
-  let cwd = process.cwd();
+/**
+ * detect js package manager
+ * currently only looks for lockfiles (ex: package-lock.json)
+ * */
+export function detectJsPackageManager(opts?: {
+  cwd?: string,
+  workspaceRootPath?: string,
+}) {
+  let cwd = opts?.cwd || process.cwd();
   const cwdParts = cwd.split('/');
+  do {
+    let pm: JsPackageManager;
+    for (pm in JS_PACKAGE_MANAGERS) {
+      const lockFilePath = path.join(
+        cwd,
+        JS_PACKAGE_MANAGERS[pm].lockfile,
+      );
 
-  let packageManager: PackageManager | undefined;
-  let possibleRootPackage: string | undefined;
-
-  while (!packageManager) {
-    // we could also try to detect the current package manager via env vars (ex: process.env.PNPM_PACKAGE_NAME)
-    // and then not check for all of the lockfiles...?
-
-
-    const filesFound = await asyncMapValues(
-      PACKAGE_MANAGER_RELEVANT_FILES,
-      // eslint-disable-next-line @typescript-eslint/no-loop-func
-      async (filePath) => pathExists(path.resolve(cwd, filePath)),
-    );
-
-    if (filesFound.packageJson) possibleRootPackage = cwd;
-
-    if (filesFound.pnpmLock || filesFound.pnpmWorkspace) packageManager = 'pnpm';
-    else if (filesFound.npmLock) packageManager = 'npm';
-    else if (filesFound.yarnLock) packageManager = 'yarn';
-    else if (filesFound.bunLock) packageManager = 'bun';
-    else if (filesFound.moonWorkspace) packageManager = 'moon';
-
-    if (!packageManager) {
-      cwdParts.pop();
-      cwd = cwdParts.join('/');
-    }
-    // show some hopefully useful error messaging if we hit the root folder without finding anything
-    if (cwd === '') {
-      console.log(kleur.red('Unable to detect your package manager and workspace root!'));
-      if (possibleRootPackage) {
-        console.log(`But it looks like your workspace root might be ${kleur.green().italic(possibleRootPackage)}`);
+      if (pathExistsSync(lockFilePath)) {
+        return JS_PACKAGE_MANAGERS[pm];
       }
-      console.log('We look for lock files (ex: package-lock.json) so you may just need to run a dependency install, for example `npm install`');
-      process.exit(1);
+    }
+
+    cwdParts.pop();
+    cwd = cwdParts.join('/');
+    if (opts?.workspaceRootPath && opts.workspaceRootPath === cwd) break;
+  } while (cwd);
+
+  // if we did not find a lockfile, we'll look at env vars for other hints
+  if (process.env.npm_config_user_agent) {
+    const pmFromAgent = process.env.npm_config_user_agent.split('/')[0];
+    if (Object.keys(JS_PACKAGE_MANAGERS).includes(pmFromAgent)) {
+      return JS_PACKAGE_MANAGERS[pmFromAgent as JsPackageManager];
     }
   }
 
-
-  return {
-    packageManager,
-    rootWorkspacePath: cwd,
-  };
+  // show some hopefully useful error messaging if we hit the root folder without finding anything
+  console.log(kleur.red('Unable to find detect your js package manager!'));
+  console.log('We look for lock files (ex: package-lock.json) so you may just need to run a dependency install (ie `npm install`)');
+  process.exit(1);
 }
-
-
-// sync version of above fn, probably dont want this... but fine for now
-export function detectPackageManagerSync() {
-  let cwd = process.cwd();
-
-  const cwdParts = cwd.split('/');
-
-  let packageManager: PackageManager | undefined;
-  let possibleRootPackage: string | undefined;
-
-  while (!packageManager) {
-    // we could also try to detect the current package manager via env vars (ex: process.env.PNPM_PACKAGE_NAME)
-    // and then not check for all of the lockfiles...?
-
-    const filesFound: Partial<Record<keyof typeof PACKAGE_MANAGER_RELEVANT_FILES, boolean>> = {};
-    for (const fileKey of Object.keys(PACKAGE_MANAGER_RELEVANT_FILES)) {
-      const key = fileKey as keyof typeof PACKAGE_MANAGER_RELEVANT_FILES;
-      const filePath = path.resolve(cwd, PACKAGE_MANAGER_RELEVANT_FILES[key]);
-      filesFound[key] = pathExistsSync(filePath);
-    }
-
-    if (filesFound.packageJson) possibleRootPackage = cwd;
-
-    if (filesFound.pnpmLock || filesFound.pnpmWorkspace) packageManager = 'pnpm';
-    else if (filesFound.npmLock) packageManager = 'npm';
-    else if (filesFound.yarnLock) packageManager = 'yarn';
-    else if (filesFound.bunLock) packageManager = 'bun';
-    else if (filesFound.moonWorkspace) packageManager = 'moon';
-
-    if (!packageManager) {
-      cwdParts.pop();
-      cwd = cwdParts.join('/');
-    }
-    // show some hopefully useful error messaging if we hit the root folder without finding anything
-    if (cwd === '') {
-      console.log(kleur.red('Unable to find detect your package manager and workspace root!'));
-      if (possibleRootPackage) {
-        console.log(`But it looks like your workspace root might be ${kleur.green().italic(possibleRootPackage)}`);
-      }
-      console.log('We look for lock files (ex: package-lock.json) so you may just need to run a dependency install (ie `npm install`)');
-      process.exit(1);
-    }
-  }
-
-  return {
-    packageManager,
-    rootWorkspacePath: cwd,
-  };
-}
-
 
 
 

--- a/packages/core/src/lib/fs-utils.ts
+++ b/packages/core/src/lib/fs-utils.ts
@@ -1,0 +1,20 @@
+import { accessSync } from 'fs';
+import { access } from 'fs/promises';
+
+export async function pathExists(p: string) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function pathExistsSync(p:string) {
+  try {
+    accessSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Previously we relied completely on (js) package managers to get the workspace package/project globs, for example `pnpm-workspace.yaml` (pnpm) or the `workspaces` key in `package.json` files (npm, yarn, bun).

This creates problems in a monorepo that is not only using one of these package manager or using it to manage the monorepo. For example, one can imagine a monorepo that has several child "monorepos" managed by pnpm within it, or a polyglot case where there is no central package manager handling everything.

Now instead we will walk up from the current directory to the git root (if applicable), and if we ever find a `.dmno/dmno-workspace.yaml` file, it will be considered the root and override everything else. Otherwise we'll rely on the js package managers, or fallback to the git root if nothing else is found.