### PR TITLE
ducktype instanceof DmnoDataType

### DIFF
--- a/.changeset/chilled-planets-glow.md
+++ b/.changeset/chilled-planets-glow.md
@@ -1,0 +1,5 @@
+---
+"dmno": patch
+---
+
+fix for instanceof checks on DmnoDataType

--- a/example-repo/.dmno/config.mts
+++ b/example-repo/.dmno/config.mts
@@ -90,6 +90,7 @@ export default defineDmnoService({
       value: switchByNodeEnv({
         _default: EncryptedVaultSecrets.item(),
         staging: switchBy('CONTEXT', {
+          _default: undefined,
           'branch-preview': EncryptedVaultSecrets.item(),
           'pr-preview': EncryptedVaultSecrets.item(),
         }),

--- a/example-repo/packages/webapp/.dmno/config.mts
+++ b/example-repo/packages/webapp/.dmno/config.mts
@@ -81,7 +81,7 @@ export default defineDmnoService({
     },
     SWITCH_EXAMPLE: {
       value: switchByNodeEnv({
-        _default: 'default-val',
+        _default: 'dev-value',
         staging: 'staging-value',
         production: (ctx) => `prod-${DMNO_CONFIG.NODE_ENV}`,
       })

--- a/packages/core/src/config-engine/authoring-utils.ts
+++ b/packages/core/src/config-engine/authoring-utils.ts
@@ -21,7 +21,7 @@ export function createVendorSchema(
 ) {
   if (!commonTraits) return schema;
   return _.mapValues(schema, (item, _itemKey) => {
-    if (item instanceof DmnoDataType || _.isString(item) || _.isFunction(item)) {
+    if (DmnoDataType.checkInstanceOf(item) || _.isString(item) || _.isFunction(item)) {
       return {
         extends: item,
         ...commonTraits,

--- a/packages/core/src/config-engine/base-types.ts
+++ b/packages/core/src/config-engine/base-types.ts
@@ -124,7 +124,7 @@ export class DmnoDataType<InstanceOptions = any> {
 
     // value resolvers have shorthands that can be passed in (static value, functions)
     // so we'll make sure those are initialized properly as well
-    if (this.typeDef.value !== undefined) {
+    if ('value' in this.typeDef) {
       this._valueResolver = processInlineResolverDef(this.typeDef.value);
     }
 
@@ -536,7 +536,7 @@ const StringDataType = createDmnoDataType({
 
     // special handling to not allow empty strings (unless explicitly allowed)
     if (val === '' && !settings.allowEmpty) {
-      return [new ValidationError('If set, string must not be empty')];
+      return [new ValidationError('If set, string must not be empty. Use `allowEmpty` option if this is intended.')];
     }
 
     if (settings.minLength !== undefined && val.length < settings.minLength) {

--- a/packages/core/src/config-engine/base-types.ts
+++ b/packages/core/src/config-engine/base-types.ts
@@ -59,10 +59,13 @@ export type ExtractSettingsSchema<F> =
 
 
 export class DmnoDataType<InstanceOptions = any> {
-  // NOTE - note quite sure about this setup yet...
-  // but the idea is to provide a wrapped version of the validate/coerce (the fns that need the type instance options)
-  // while providing transparent access to the rest. This is so the ConfigItem can just walk up the chain of types
-  // without having to understand the details... The other option is to revert that change and
+  /** use instead of `instanceof DmnoDataType`
+   * because there can be a different copy of dmno being used within vite from the dmno config loading process
+   * */
+  static checkInstanceOf(other: any) {
+    return other?.typeDef && other?.primitiveTypeFactory;
+  }
+
 
   parentType?: DmnoDataType;
   private _valueResolver?: ConfigValueResolver;
@@ -94,13 +97,13 @@ export class DmnoDataType<InstanceOptions = any> {
       // deal with uninitialized case - `extends: DmnoBaseTypes.number`
       } else if (_.isFunction(this.typeDef.extends)) {
         const initializedDataType = this.typeDef.extends(typeInstanceOptions as any);
-        if (initializedDataType instanceof DmnoDataType) {
+        if (DmnoDataType.checkInstanceOf(initializedDataType)) {
           this.parentType = initializedDataType;
         } else {
           throw new Error('found invalid parent (as result of fn) in extends chain');
         }
       // normal case - `extends: DmnoBaseTypes.number({ ... })`
-      } else if (this.typeDef.extends instanceof DmnoDataType) {
+      } else if (DmnoDataType.checkInstanceOf(this.typeDef.extends)) {
         this.parentType = this.typeDef.extends;
       // anything else is considered an error
       } else if (this.typeDef.extends) {

--- a/packages/core/src/config-engine/config-engine.ts
+++ b/packages/core/src/config-engine/config-engine.ts
@@ -1200,15 +1200,15 @@ export class DmnoConfigItem extends DmnoConfigItemBase {
     } else if (_.isFunction(defOrShorthand)) {
       // in this case, we have no settings to pass through, so we pass an empty object
       const shorthandFnResult = defOrShorthand({});
-      if (!(shorthandFnResult instanceof DmnoDataType)) {
+      if (!DmnoDataType.checkInstanceOf(shorthandFnResult)) {
         // TODO: put this in schema error instead?
         console.log(DmnoDataType, shorthandFnResult);
         throw new Error('invalid schema as result of fn shorthand');
       } else {
         this.type = shorthandFnResult;
       }
-    } else if (defOrShorthand instanceof DmnoDataType) {
-      this.type = defOrShorthand;
+    } else if (DmnoDataType.checkInstanceOf(defOrShorthand)) {
+      this.type = defOrShorthand as DmnoDataType;
     } else if (_.isObject(defOrShorthand)) {
       // this is the only real difference b/w the handling of extends...
       // we create a DmnoDataType directly without a reusable type for the items defined in the schema directly

--- a/packages/core/src/config-engine/resolvers/resolvers.ts
+++ b/packages/core/src/config-engine/resolvers/resolvers.ts
@@ -9,7 +9,10 @@ import { SerializedResolver } from '../../config-loader/serialization-types';
 
 // TODO: do we allow Date?
 // what to do about null/undefined?
-export type ConfigValue = string | number | boolean | null | { [key: string]: ConfigValue } | Array<ConfigValue>;
+export type ConfigValue =
+  string | number | boolean | null | undefined |
+  { [key: string]: ConfigValue } |
+  Array<ConfigValue>;
 
 type ValueResolverResult = undefined | ConfigValue;
 type ConfigValueInlineFunction =
@@ -308,15 +311,13 @@ export function processInlineResolverDef(resolverDef: InlineValueResolverDef) {
   } else if (resolverDef instanceof ConfigValueResolver) {
     return resolverDef;
 
-  // static value case
-  } else if (resolverDef !== undefined) {
+  // static value case - including undefined
+  } else {
     return createResolver({
       icon: 'material-symbols:check-circle',
       label: 'static',
       resolve: async () => resolverDef,
     });
-  } else {
-    throw new Error('invalid resolver definition');
   }
 }
 

--- a/packages/core/src/config-engine/resolvers/switch-resolver.ts
+++ b/packages/core/src/config-engine/resolvers/switch-resolver.ts
@@ -6,7 +6,10 @@ import {
 } from './resolvers';
 import { ResolverContext } from '../config-engine';
 
-type SwitchByResolverOptions = Record<string, InlineValueResolverDef>;
+type SwitchByResolverOptions =
+  // a default value is required, even if undefined - can be set via `_` or `_default`
+  ({ '_': InlineValueResolverDef } | { '_default': InlineValueResolverDef })
+  & { [value: string]: InlineValueResolverDef };
 
 export const switchBy = (switchByKey: string, branches: SwitchByResolverOptions) => {
   return createResolver({

--- a/packages/core/src/config-loader/vite-server.ts
+++ b/packages/core/src/config-loader/vite-server.ts
@@ -15,18 +15,18 @@ export async function setupViteServer(
     // meaning we have 2 copies of classes and `instanceof` stops working
     enforce: 'pre', // Run before the builtin 'vite:resolve' of Vite
     async resolveId(source, importer, options) {
-      // console.log(kleur.bgCyan('PLUGIN RESOLVE!'), source, importer, options);
+      // console.log('PLUGIN RESOLVE!', source, importer, options);
 
       if (source === 'dmno') {
         // const resolution = await this.resolve(source, importer, options);
-        // console.log('resolution', resolution);
+        // console.log('dmno resolution', resolution);
         // if (!resolution) return;
 
         return {
           // pointing at dist/index is hard-coded...
           // we could extract the main entry point from the resolution instead?
-          id: '/node_modules/dmno/dist/index.js',
-          // I believe this path is appended to our "root" which is our workpace root
+          id: `${workspaceRootPath}/node_modules/dmno/dist/index.js`,
+          external: 'absolute',
         };
       }
     },

--- a/packages/docs-site/src/content/docs/docs/guides/schema.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/schema.mdx
@@ -427,7 +427,7 @@ export default defineDmnoService({
 });
 ```
 
-Internally, we even wrap the static values and inline functions into resolvers, so that we can always display some additional metadata about _how_ the value is being set - even without actually resolving it. These resolvers can also return more resolvers, and have a notion of multiple branches built in, leading to some very powerful composition capabilities.
+Internally, we even wrap the static values and inline functions into resolvers, so that we can always display some additional metadata about _how_ the value is being set - even without actually resolving it. Resolvers also have a notion of multiple branches built in, which can then use more resolvers. This enables some very powerful composition capabilities.
 
 An quick example to illustrate using our built-in [`switchBy`](/docs/reference/helper-methods/#switchby) resolver which selects a value based on the current value of another within your config.
 
@@ -441,7 +441,7 @@ export default defineDmnoService({
         _default: 'dev123',
         test: 'test123',
         staging: 'staging123',
-        // sensitive key we don't want in our repo
+        // sensitive key we need to pull from somewhere secure
         production: prodOnePassSecrets.item(),
       }),
     },

--- a/packages/docs-site/src/content/docs/docs/reference/helper-methods.mdx
+++ b/packages/docs-site/src/content/docs/docs/reference/helper-methods.mdx
@@ -397,11 +397,14 @@ This method is used to define different configurations for different values of a
 
 ```typescript
 type opts = {
-  _default?: any;
+  _default: any;
   [key: string]: any;
 };
 ```
-Note: `_default` is a reserved key that will be used if the current key is not defined in the object. All the other keys should match the possible values of the `SWITCH_BY_KEY` config item.
+
+Note: `_default` is a reserved key that will be used if the current value is not found. All the other keys should match the possible values of the `SWITCH_BY_KEY` config item. **You must set `_default` value in the switch object, even if it is `_default: undefined`.**
+
+
 
 Example: 
 ```javascript
@@ -433,7 +436,7 @@ This method is used to define different configurations for different environment
 
 ```typescript
 type SwitchByNodeEnvOpts = {
-  _default?: any;
+  _default: any;
   development?: any;
   staging?: any;
   production?: any;


### PR DESCRIPTION
having some issues around `instanceof DmnoDataType` checks because the copy of `DmnoDataType` within the vite-loaded config files is different than the config loader process.

For now we'll just do some duck-type checks instead, but need to think through this further!