### PR TITLE
fix for single-repo w/o git

### DIFF
--- a/.changeset/serious-clocks-taste.md
+++ b/.changeset/serious-clocks-taste.md
@@ -1,0 +1,5 @@
+---
+"dmno": patch
+---
+
+support workspace root detection in single-repo without git

--- a/packages/core/src/cli/commands/init.command.ts
+++ b/packages/core/src/cli/commands/init.command.ts
@@ -11,7 +11,7 @@ import {
 import { tryCatch } from '@dmno/ts-lib';
 
 import gradient from 'gradient-string';
-import { PackageManager, findDmnoServices, pathExists } from '../../config-loader/find-services';
+import { findDmnoServices, pathExists } from '../../config-loader/find-services';
 import { DmnoCommand } from '../lib/dmno-command';
 
 import { formatError, formattedValue, joinAndCompact } from '../lib/formatting';
@@ -23,6 +23,7 @@ import {
 import { initDmnoForService } from '../lib/init-helpers';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../../lib/constants';
 import { CliExitError } from '../lib/cli-error';
+import { detectJsPackageManager } from '../../lib/detect-package-manager';
 
 const program = new DmnoCommand('init')
   .summary('Sets up dmno')
@@ -46,7 +47,9 @@ program.action(async (opts: {
 
   const rootPath = workspaceInfo.workspacePackages[0].path;
 
-  console.log(kleur.gray(`- Package manager: ${workspaceInfo.packageManager}`));
+  const packageManager = detectJsPackageManager();
+
+  console.log(kleur.gray(`- Package manager: ${packageManager.name}`));
   console.log(kleur.gray(`- Workspace root path: ${rootPath}`));
   if (workspaceInfo.isMonorepo) {
     console.log(kleur.gray(`- Monorepo mode: ENABLED (${workspaceInfo.workspacePackages.length - 1} child packages)`));

--- a/packages/core/src/config-loader/find-services.ts
+++ b/packages/core/src/config-loader/find-services.ts
@@ -76,6 +76,11 @@ export async function findDmnoServices(includeUnitialized = true): Promise<Scann
         const filePath = path.join(cwd, globLocation.file);
         if (!await pathExists(filePath)) continue;
 
+        // assume first package.json file found is root until we find evidence otherwise
+        if (globLocation.file === 'package.json' && !dmnoWorkspaceRootPath) {
+          dmnoWorkspaceRootPath = cwd;
+        }
+
         debug(`looking for workspace globs in ${filePath} > ${globLocation.path}`);
         const fileType = path.extname(filePath);
         let fileContents: any;


### PR DESCRIPTION
I noticed that when working in a non-monorepo that is not (yet) a git repo, that workspace root detection was failing.