### PR TITLE
Fix: Update add item example command

### DIFF
--- a/.changeset/lazy-queens-return.md
+++ b/.changeset/lazy-queens-return.md
@@ -1,0 +1,5 @@
+---
+"@dmno/encrypted-vault-plugin": patch
+---
+
+Fix: Update add item example command

--- a/packages/plugins/encrypted-vault/src/cli/setup.command.ts
+++ b/packages/plugins/encrypted-vault/src/cli/setup.command.ts
@@ -187,7 +187,7 @@ export const SetupCommand = createDmnoPluginCliCommand({
         kleur.bold('This file is safe/intended to be committed to source control!'),
         '',
         'To start adding items, run',
-        kleur.magenta(`pnpm exec dmno plugin -p ${ctx.plugin.instanceId} -- add-item`),
+        kleur.magenta(`pnpm exec dmno plugin -p ${ctx.plugin.instanceId} -- add`),
       ].join('\n'));
 
       process.exit(0);


### PR DESCRIPTION
This changed from `add-item` to just `add` 
See: https://github.com/dmno-dev/dmno/blob/c54dbc526c75666c6ddc6b29ca16ff289c01f0d1/packages/plugins/encrypted-vault/src/cli/upsert.command.ts#L57