### PR TITLE
Override loader system

### DIFF
--- a/.changeset/breezy-horses-cough.md
+++ b/.changeset/breezy-horses-cough.md
@@ -1,0 +1,6 @@
+---
+"@dmno/configraph": patch
+"dmno": patch
+---
+
+infer required:true if static value is set

--- a/.changeset/chatty-dots-invite.md
+++ b/.changeset/chatty-dots-invite.md
@@ -1,0 +1,6 @@
+---
+"@dmno/1password-plugin": patch
+"dmno": patch
+---
+
+introduce override loader system and 1pass override loader

--- a/.changeset/mighty-beers-join.md
+++ b/.changeset/mighty-beers-join.md
@@ -1,0 +1,5 @@
+---
+"dmno": patch
+---
+
+adjust tsconfig to make schema use .d.ts

--- a/example-repo/.dmno/config.mts
+++ b/example-repo/.dmno/config.mts
@@ -1,5 +1,5 @@
-import { DmnoBaseTypes, defineDmnoService, NodeEnvType, switchBy, inject } from 'dmno';
-import { OnePasswordDmnoPlugin, OnePasswordTypes } from '@dmno/1password-plugin';
+import { DmnoBaseTypes, defineDmnoService, NodeEnvType, switchBy, inject, processEnvOverrideLoader, dotEnvFileOverrideLoader } from 'dmno';
+import { OnePasswordDmnoPlugin, OnePasswordTypes, onePasswordOverrideLoader } from '@dmno/1password-plugin';
 import { BitwardenSecretsManagerDmnoPlugin, BitwardenSecretsManagerTypes } from '@dmno/bitwarden-plugin';
 import { InfisicalDmnoPlugin, InfisicalTypes } from '@dmno/infisical-plugin';
 import { EncryptedVaultDmnoPlugin, EncryptedVaultTypes } from '@dmno/encrypted-vault-plugin';
@@ -34,6 +34,16 @@ export default defineDmnoService({
     redactSensitiveLogs: true,
     preventClientLeaks: true,
   },
+  overrides: [
+    // loads overrides from shell environment (process.env)
+    processEnvOverrideLoader(),
+    // looks for .env files (.env, .env.local, etc)
+    dotEnvFileOverrideLoader(),
+    // personal overrides, create item in "Employee" vault with this name, item label must match 
+    onePasswordOverrideLoader({ reference: 'op://Employee/dmno-local-dev-overrides/root' }, { ignoreMissing: true }),
+    // shared overrides
+    onePasswordOverrideLoader({ reference: 'op://dev test/rznyyjrwcv5sgc4ykjhzpkoevm/root' }),
+  ],
   schema: {
     ITEM_X: { 
       value: 'should-be-required',
@@ -42,7 +52,7 @@ export default defineDmnoService({
     NODE_ENV: NodeEnvType,
     DMNO_ENV: {
       typeDescription: 'standardized environment flag set by DMNO',
-      value: (ctx) => ctx.get('NODE_ENV'),
+      value: () => DMNO_CONFIG.NODE_ENV,
     },
     INFISICAL_CLIENT_SECRET: {
       extends: InfisicalTypes.clientSecret,

--- a/example-repo/.dmno/config.mts
+++ b/example-repo/.dmno/config.mts
@@ -35,6 +35,10 @@ export default defineDmnoService({
     preventClientLeaks: true,
   },
   schema: {
+    ITEM_X: { 
+      value: 'should-be-required',
+    },
+
     NODE_ENV: NodeEnvType,
     DMNO_ENV: {
       typeDescription: 'standardized environment flag set by DMNO',

--- a/example-repo/packages/api/.dmno/config.mts
+++ b/example-repo/packages/api/.dmno/config.mts
@@ -11,7 +11,7 @@ export default defineDmnoService({
   overrides: [
     processEnvOverrideLoader(),
     // personal overrides, create item in "Employee" vault with this name, item label must match 
-    onePasswordOverrideLoader({ name: 'dmno-local-dev-overrides' }), // defaults to field matching service name ("api")
+    onePasswordOverrideLoader({ reference: 'op://Employee/dmno-local-dev-overrides/api' }),
     // shared overrides
     onePasswordOverrideLoader({ reference: 'op://dev test/rznyyjrwcv5sgc4ykjhzpkoevm/api' }),
   ],

--- a/example-repo/packages/api/.dmno/config.mts
+++ b/example-repo/packages/api/.dmno/config.mts
@@ -1,5 +1,5 @@
-import { defineDmnoService, DmnoBaseTypes, switchBy } from 'dmno';
-import { OnePasswordDmnoPlugin } from '@dmno/1password-plugin';
+import { defineDmnoService, DmnoBaseTypes, switchBy, processEnvOverrideLoader } from 'dmno';
+import { OnePasswordDmnoPlugin, onePasswordOverrideLoader } from '@dmno/1password-plugin';
 import { EncryptedVaultDmnoPlugin } from '@dmno/encrypted-vault-plugin';
 
 const OnePassBackend = OnePasswordDmnoPlugin.injectInstance('1pass');
@@ -8,11 +8,22 @@ const VaultPlugin = EncryptedVaultDmnoPlugin.injectInstance('vault/prod');
 export default defineDmnoService({
   name: 'api',
   parent: 'group1',
+  overrides: [
+    processEnvOverrideLoader(),
+    // personal overrides, create item in "Employee" vault with this name, item label must match 
+    onePasswordOverrideLoader({ name: 'dmno-local-dev-overrides' }), // defaults to field matching service name ("api")
+    // shared overrides
+    onePasswordOverrideLoader({ reference: 'op://dev test/rznyyjrwcv5sgc4ykjhzpkoevm/api' }),
+  ],
   pick: [
     'NODE_ENV',
     'DMNO_ENV',
   ],
   schema: {
+    OVERRIDE_ME: {
+      value: 'default'
+    },
+
     OP_ITEM_1: {
       value: OnePassBackend.item(),
     },

--- a/example-repo/packages/dmno-ui-demo/.dmno/config.mts
+++ b/example-repo/packages/dmno-ui-demo/.dmno/config.mts
@@ -9,7 +9,6 @@ const OnePassSecrets = OnePasswordDmnoPlugin.injectInstance('1pass');
 // throw new Error('bloop');
 
 export default defineDmnoService({
-  // name: 'dmno-ui-demo',
   settings: {
     interceptSensitiveLeakRequests: true,
     redactSensitiveLogs: true,
@@ -83,21 +82,25 @@ export default defineDmnoService({
       extends: DmnoBaseTypes.number(),
       value: 'not-a-number',
     },
-    SCHEMA_ERROR_EXAMPLE: {
-      // value: configPath('bad-entity-id', 'bad-path'),
-    },
-    RESOLUTION_ERROR_EXAMPLE: {
-      value: OnePassSecrets.itemByReference('badreference'),
-    },
+    // SCHEMA_ERROR_EXAMPLE: {
+    //   // schema error blocks resolution
+    //   value: configPath('bad-entity-id', 'bad-path'),
+    // },
+    // OP_BAD_FIELD: {
+    //   value: OnePassSecrets.itemByReference("op://dev test/example/bad-section/bad-id"),
+    // },
+    // OP_BAD_VAULT: {
+    //   value: OnePassSecrets.itemByReference('op://not-a-vault/not-an-item/not-a-path'),
+    // }, 
+    // OP_BAD_ITEM: {
+    //   value: OnePassSecrets.itemByReference('op://dev test/not an item/not-a-path'),
+    // },
     WARNING_EXAMPLE: {
       value: 'foo',
       validate(val) {
         throw new ValidationError('this is a warning', { isWarning: true });
       }
     },
-    // RESOLVER_CRASH_EXAMPLE: {
-    //   value: OnePassSecrets.itemByLink('badlink', 'asdf'),
-    // }
   }
 });
 

--- a/packages/configraph/package.json
+++ b/packages/configraph/package.json
@@ -11,7 +11,7 @@
   },
   "bugs": "https://github.com/dmno-dev/dmno/issues",
   "homepage": "https://dmno.dev",
-  "keywords": [],
+  "keywords": [ ],
   "scripts": {
     "clean": "rm -rf dist",
     "build": "pnpm run clean && tsup",
@@ -53,6 +53,7 @@
     "debug": "catalog:",
     "kleur": "catalog:",
     "lodash-es": "catalog:",
+    "modern-async": "catalog:",
     "svgo": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/configraph/src/errors.ts
+++ b/packages/configraph/src/errors.ts
@@ -46,6 +46,10 @@ export class ConfigraphError extends Error {
     tip?: string | Array<string>,
     err?: Error,
     isWarning?: boolean,
+    /** machine-friendly error code if needed for anything else */
+    code?: string,
+    /** free-form additional metadata */
+    extraMetadata?: Record<string, any>,
   }) {
     if (_.isError(errOrMessage)) {
       super(errOrMessage.message);
@@ -68,6 +72,12 @@ export class ConfigraphError extends Error {
     return this.more.tip;
   }
 
+  get code() {
+    return this.more?.code;
+  }
+  get extraMetadata() {
+    return this.more?.extraMetadata;
+  }
 
   set isWarning(w: boolean) {
     this._isWarning = w;
@@ -131,7 +141,13 @@ export class CoercionError extends ConfigraphError {
 }
 export class ResolutionError extends ConfigraphError {
   static defaultIcon = '⛔';
-  retryable?: boolean = false;
+  protected _retryable?: boolean = false;
+  set retryable(val: boolean) { this._retryable = val; }
+  get retryable() {
+    if (this._retryable) return true;
+    if (this.originalError instanceof ResolutionError) return this.originalError.retryable;
+    return false;
+  }
 }
 
 export class EmptyRequiredValueError extends ValidationError {

--- a/packages/configraph/src/graph.ts
+++ b/packages/configraph/src/graph.ts
@@ -2,6 +2,7 @@ import _ from 'lodash-es';
 import graphlib from '@dagrejs/graphlib';
 import Debug from 'debug';
 
+import { asyncForEach } from 'modern-async';
 import { ConfigraphNode } from './config-node';
 import { SchemaError } from './errors';
 import { ConfigraphEntity, ConfigraphEntityDef } from './entity';
@@ -370,7 +371,8 @@ export class Configraph<
     while (nodeIdsToResolve.length) {
       let resolvedCount = 0;
       debug('resolving batch', nodeIdsToResolve);
-      for (const nodeId of nodeIdsToResolve) {
+      // eslint-disable-next-line @typescript-eslint/no-loop-func
+      await asyncForEach(nodeIdsToResolve, async (nodeId) => {
         const node = this.nodesByFullPath[nodeId];
         // currently this resolve fn will trigger resolve on nested items
         const nodeWasResolved = node.isResolved;
@@ -383,7 +385,8 @@ export class Configraph<
         if (!node.isFullyResolved) {
           nextBatchNodeIds.push(nodeId);
         }
-      }
+      }, Infinity);
+      //! What concurrency limit do we want to impose?
 
       if (nextBatchNodeIds.length > 0) {
         // if this batch yielded no new resolutions, we can stop

--- a/packages/configraph/src/plugin.ts
+++ b/packages/configraph/src/plugin.ts
@@ -129,12 +129,12 @@ EntityClass extends ConfigraphEntity = ConfigraphEntity,
 
     if (!node.isResolved) {
       throw new DependencyNotResolvedResolutionError(
-        `Tried to access node that was not yet resolved - ${nodePath}`,
+        `Plugin input tried to access node that was not yet resolved - ${nodePath}`,
       );
     }
     if (!node.isValid) {
       throw new DependencyInvalidResolutionError(
-        `Resolver tried to use node that is invalid - ${nodePath}`,
+        `Plugin input resolver tried to use node that is invalid - ${nodePath}`,
       );
     }
 

--- a/packages/configraph/src/resolvers.ts
+++ b/packages/configraph/src/resolvers.ts
@@ -98,7 +98,7 @@ export function createResolver(
 
 //! maybe do this via a type/errorCode instead of custom class?
 export class DependencyNotResolvedResolutionError extends ResolutionError {
-  retryable = true;
+  _retryable = true;
 }
 export class DependencyInvalidResolutionError extends ResolutionError {}
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -133,7 +133,7 @@
     "lodash-es": "catalog:",
     "log-update": "^6.0.0",
     "magic-string": "^0.30.12",
-    "modern-async": "^2.0.0",
+    "modern-async": "catalog:",
     "node-forge": "^1.3.1",
     "outdent": "^0.8.0",
     "picomatch": "^3.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/vendor-types/index.js",
       "types": "./dist/vendor-types/index.d.ts"
     },
+    "./utils": {
+      "ts-src": "./src/utils.ts",
+      "import": "./dist/utils.js",
+      "types": "./dist/utils.d.ts"
+    },
     "./cli-lib": {
       "ts-src": "./src/cli/plugin-cli-lib.ts",
       "import": "./dist/cli/plugin-cli-lib.js",

--- a/packages/core/src/config-engine/overrides.ts
+++ b/packages/core/src/config-engine/overrides.ts
@@ -1,0 +1,102 @@
+import _ from 'lodash-es';
+import { loadServiceDotEnvFiles } from '../lib/dotenv-utils';
+//! need to clean up overrrides
+type NestedOverrideObj<T = string> = {
+  [key: string]: NestedOverrideObj<T> | T;
+};
+
+export class OverrideSource {
+  constructor(
+    readonly type: string,
+    readonly label: string | undefined,
+    readonly icon: string,
+    readonly values: NestedOverrideObj,
+    readonly enabled = true,
+  ) {}
+
+  /** get an env var override value using a dot notation path */
+  getOverrideForPath(path: string) {
+    return _.get(this.values, path);
+  }
+}
+
+type MaybePromise<T> = T | Promise<T>;
+export type DmnoOverrideLoader = {
+  load: (ctx: DmnoOverrideLoaderCtx) => MaybePromise<Array<OverrideSource>>
+};
+
+export type DmnoOverrideLoaderCtx = {
+  serviceId: string,
+  servicePath: string,
+};
+
+
+// ~ load overrides from process (`process.env`) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/**
+ * parse env vars into an object, using a special separator to denote nesting.
+ * This idea comes from https://www.npmjs.com/package/nconf
+ *
+ * for example PARENT_ITEM__CHILD_ITEM=foo would result in
+ * { PARENT_ITEM: { CHILD_ITEM: "foo" } }
+ */
+export function getConfigFromEnvVars(
+  /** separator to interpret as nesting, defaults to "__" */
+  separator = '__',
+) {
+  const config = {} as Record<string, any>;
+  _.each(process.env, (val, key) => {
+    const path = key.replaceAll(separator, '.');
+    // _.set deals with initializing objects when necessary
+    _.set(config, path, val);
+  });
+  return config;
+}
+
+
+export function processEnvOverrideLoader(): DmnoOverrideLoader {
+  return {
+    load() {
+      // TODO: can cache this and return same source
+      return [
+        new OverrideSource('process', undefined, 'ri:terminal-box-fill', getConfigFromEnvVars()),
+      ];
+    },
+  };
+}
+
+
+// ~ load overrides from dotenv files ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+export function dotEnvFileOverrideLoader(): DmnoOverrideLoader {
+  return {
+    async load(ctx: DmnoOverrideLoaderCtx) {
+      // TODO: this is not at all optimized for speed...
+      // particularly it is doing a check on if the file is gitignored
+      // and if we are loading not in dev mode, we may just want to load files that will be applied
+      const dotEnvFiles = await loadServiceDotEnvFiles(ctx.servicePath, { onlyLoadDmnoFolder: true });
+
+      // TODO: support other formats (yaml, toml, json) - probably should all be through a plugin system
+
+      // loads multiple override files, in order from more specific to least
+      // .env.{ENV}.local
+      // .env.local
+      // .env.{ENV}
+      // .env
+
+      const dotenvOverrideSources = _.map(dotEnvFiles, (dotEnvFile) => {
+        return new OverrideSource(
+          '.env file',
+          dotEnvFile.fileName,
+          'simple-icons:dotenv',
+          dotEnvFile.envObj,
+          // TODO: specific env overrides are being enabled based on process.env.NODE_ENV
+          // we probably want to be smarter about how _that_ gets resolved first
+          // and store it at the workspace level or something...?
+          !dotEnvFile.applyForEnv || dotEnvFile.applyForEnv === process.env.NODE_ENV,
+        );
+      });
+      return dotenvOverrideSources;
+    },
+  };
+}

--- a/packages/core/src/config-engine/overrides.ts
+++ b/packages/core/src/config-engine/overrides.ts
@@ -33,6 +33,7 @@ export type DmnoOverrideLoaderCtx = {
 
 // ~ load overrides from process (`process.env`) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+let originalProcessEnv: Record<string, any> | undefined;
 /**
  * parse env vars into an object, using a special separator to denote nesting.
  * This idea comes from https://www.npmjs.com/package/nconf
@@ -44,12 +45,14 @@ export function getConfigFromEnvVars(
   /** separator to interpret as nesting, defaults to "__" */
   separator = '__',
 ) {
+  if (originalProcessEnv) return originalProcessEnv;
   const config = {} as Record<string, any>;
   _.each(process.env, (val, key) => {
     const path = key.replaceAll(separator, '.');
     // _.set deals with initializing objects when necessary
     _.set(config, path, val);
   });
+  originalProcessEnv = config;
   return config;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,5 +12,10 @@ export * from './globals-injector/injector';
 
 export * from './config-loader/serialization-types';
 
+export {
+  DmnoOverrideLoader, OverrideSource,
+  processEnvOverrideLoader, dotEnvFileOverrideLoader,
+} from './config-engine/overrides';
+
 // used by 1pass plugin - will likely extract eventually
 export * from './lib/dotenv-utils';

--- a/packages/core/src/lib/async-utils.ts
+++ b/packages/core/src/lib/async-utils.ts
@@ -48,3 +48,10 @@ export async function asyncEachParallel<V>(
 ): Promise<void> {
   return asyncForEach(iterable, iteratee, Infinity);
 }
+
+export async function asyncMapParallel<V, M>(
+  iterable: Iterable<V> | AsyncIterable<V>,
+  iteratee: (value: V, index: number, iterable: Iterable<V> | AsyncIterable<V>) => Promise<M> | M,
+): Promise<Array<M>> {
+  return asyncMap(iterable, iteratee, Infinity);
+}

--- a/packages/core/src/lib/exec-helpers.ts
+++ b/packages/core/src/lib/exec-helpers.ts
@@ -1,0 +1,64 @@
+import { spawn, exec, SpawnOptions } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createDeferredPromise } from '@dmno/ts-lib';
+
+
+export class ExecError extends Error {
+  constructor(
+    readonly exitCode: number,
+    readonly signal: NodeJS.Signals | null,
+    readonly data: string = 'command gave no output',
+  ) {
+    super(data);
+  }
+}
+
+
+export function spawnAsyncHelper(
+  command: string,
+  args: Array<string>,
+  spawnOptions?: SpawnOptions,
+) {
+  const childProcess = spawn(command, args, spawnOptions || {});
+  const spawnCompleteDeferred = createDeferredPromise<string>();
+
+  let stdoutData: string = '';
+  let stderrData: string = '';
+  childProcess.stdout?.on('data', (data) => {
+    stdoutData += data.toString();
+  });
+  childProcess.stderr?.on('data', (data) => {
+    stderrData += data.toString();
+  });
+  childProcess.stdout?.on('error', (err) => {
+    spawnCompleteDeferred.reject(err);
+  });
+  childProcess.stderr?.on('error', (err) => {
+    spawnCompleteDeferred.reject(err);
+  });
+  childProcess.on('error', (err) => {
+    spawnCompleteDeferred.reject(err);
+  });
+  childProcess.on('exit', (exitCode, signal) => {
+    if (!exitCode) {
+      spawnCompleteDeferred.resolve(stdoutData);
+    } else {
+      spawnCompleteDeferred.reject(
+        new ExecError(exitCode, signal, stderrData),
+      );
+    }
+  });
+
+  return { childProcess, execResult: spawnCompleteDeferred.promise };
+}
+
+export async function spawnAsync(
+  command: string,
+  args: Array<string>,
+  opts?: SpawnOptions,
+) {
+  const { execResult } = spawnAsyncHelper(command, args, opts);
+  return execResult;
+}
+
+export const asyncExec = promisify(exec);

--- a/packages/core/src/lib/exec-utils.ts
+++ b/packages/core/src/lib/exec-utils.ts
@@ -1,4 +1,0 @@
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
-
-export const asyncExec = promisify(exec);

--- a/packages/core/src/lib/git-utils.ts
+++ b/packages/core/src/lib/git-utils.ts
@@ -1,4 +1,4 @@
-import { asyncExec } from './exec-utils';
+import { asyncExec } from './exec-helpers';
 
 export async function checkIsFileGitIgnored(path: string, warnIfNotGitRepo = false) {
   try {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,1 +1,3 @@
+export { createDeferredPromise, DeferredPromise } from '@dmno/ts-lib';
 export { parseDotEnvContents, parsedDotEnvToObj } from './lib/dotenv-utils';
+export * from './lib/exec-helpers';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,0 +1,1 @@
+export { parseDotEnvContents, parsedDotEnvToObj } from './lib/dotenv-utils';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 
     'src/cli/cli-executable.ts', // cli that gets run via `dmno` command
     'src/cli/plugin-cli-lib.ts', // helpers used to create clis for dmno plugins
+    'src/utils.ts', // general helpers for use within plugins
   ], 
 
   // imported as TS directly, so we have to tell tsup to compile it instead of leaving it external

--- a/packages/docs-site/src/content/docs/docs/guides/typescript.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/typescript.mdx
@@ -23,7 +23,7 @@ To simplify accessing your config, we inject the `DMNO_CONFIG` and `DMNO_PUBLIC_
 The DMNO Config loader automaticaly generates TS types to be consumed by your code into the `.dmno/.typegen` directory:
 - `.dmno/.typegen/global.d.ts` - injects the `DMNO_CONFIG` global
 - `.dmno/.typegen/global-public.d.ts` - injects the `DMNO_PUBLIC_CONFIG` global
-- `.dmno/schema.ts` - the actual schema of your config, used by the `.d.ts` files
+- `.dmno/schema.d.ts` - the actual schema of your config, used by the `.d.ts` files
 
 _We use these same types to give you autocompletion when authoring your schema itself._
 

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -1,14 +1,16 @@
-import { spawnSync } from 'node:child_process';
 import Debug from 'debug';
 import { ResolutionError } from 'dmno';
-
+import {
+  ExecError, spawnAsync, createDeferredPromise, DeferredPromise,
+} from 'dmno/utils';
 
 const debug = Debug('dmno:1pass-plugin');
 
-const OP_CLI_CACHE: Record<string, any> = {}
+const ENABLE_BATCHING = true;
+
+const OP_CLI_CACHE: Record<string, any> = {};
 
 export async function execOpCliCommand(cmdArgs: Array<string>) {
-
   // very simple in-memory cache, will persist between runs in watch mode
   // but need to think through how a user can opt out
   // and interact with this cache from the web UI when we add it for the regular cache
@@ -19,39 +21,45 @@ export async function execOpCliCommand(cmdArgs: Array<string>) {
   }
 
   const startAt = new Date();
-  // using system-installed copy of `op`
-  const cmd = spawnSync('op', cmdArgs);
-  debug(`op cli command - "${cmdArgs}"`);
-  debug(`> took ${+new Date() - +startAt}ms`);
-  if (cmd.status === 0) {
-    const cliResult = cmd.stdout.toString()
-    OP_CLI_CACHE[cacheKey] = cliResult;
+
+  try {
+    // uses system-installed copy of `op`
+    const cliResult = await spawnAsync('op', cmdArgs);
+    debug(`op cli command - "${cmdArgs}"`);
+    debug(`> took ${+new Date() - +startAt}ms`);
+    // OP_CLI_CACHE[cacheKey] = cliResult;
     return cliResult;
-  } else if (cmd.error) {
-    if ((cmd.error as any).code === 'ENOENT') {
-      throw new ResolutionError('1password cli `op` not found', {
-        tip: [
-          'By not using a service account token, you are relying on your local 1password cli installation for ambient auth.',
-          'But your local 1password cli (`op`) was not found. Install it here - https://developer.1password.com/docs/cli/get-started/',
-        ],
-      });
-    } else {
-      throw new ResolutionError(`Problem invoking 1password cli: ${cmd.error.message}`);
-    }
-  } else {
-    let errMessage = cmd.stderr.toString();
+  } catch (err) {
+    throw processOpCliError(err);
+  }
+}
+
+/**
+ * help try to turn `op` errors into something more helpful
+ * this is all fairly brittle though because it depends on the error messages
+ * luckily it should only _improve_ the experience, and is not critical
+ */
+function processOpCliError(err: Error | any) {
+  if (err instanceof ExecError) {
+    let errMessage = err.data;
     // get rid of "[ERROR] 2024/01/23 12:34:56 " before actual message
-    // console.log('1pass cli error', errMessage);
+    debug('1pass cli error --', errMessage);
     if (errMessage.startsWith('[ERROR]')) errMessage = errMessage.substring(28);
     if (errMessage.includes('authorization prompt dismissed')) {
-      throw new ResolutionError('1password app authorization prompt dismissed by user', {
+      return new ResolutionError('1password app authorization prompt dismissed by user', {
         tip: [
           'By not using a service account token, you are relying on your local 1password installation',
           'When the authorization prompt appears, you must authorize/unlock 1password to allow access',
         ],
       });
     } else if (errMessage.includes("isn't a vault in this account")) {
-      throw new ResolutionError('1password vault not found in account connected to op cli', {
+      // message looks like -- "asdf" isn't a vault in this account...
+      // so we will extract the vault name/id
+      const matches = errMessage.match(/"([^"]+)" isn't a vault in this account/);
+      const vaultNameOrId = matches?.[1] || 'unknown';
+      return new ResolutionError(`1password vault "${vaultNameOrId}" not found in account connected to op cli`, {
+        code: 'BAD_VAULT_REFERENCE',
+        extraMetadata: { badVaultId: vaultNameOrId },
         tip: [
           'By not using a service account token, you are relying on your local 1password cli installation and authentication.',
           'The account currently connected to the cli does not contain (or have access to) the selected vault',
@@ -59,12 +67,46 @@ export async function execOpCliCommand(cmdArgs: Array<string>) {
           'You may need to call `op signout` and `op signin` to select the correct account.',
         ],
       });
+    } else if (errMessage.includes('could not find item')) {
+      // message includes `"item name" isn't an item in the "vault name" vault`
+      const matches = errMessage.match(/could not find item (.+) in vault (.+)/);
+      const itemNameOrId = matches?.[1] || 'unknown';
+      const vaultId = matches?.[2] || 'unknown';
+
+      // const vaultNameOrId = errMessage.substring(1, errMessage.substring(1).indexOf('"') + 1);
+      return new ResolutionError(`1password item "${itemNameOrId}" not found in vault "${vaultId}"`, {
+        code: 'BAD_ITEM_REFERENCE',
+        extraMetadata: { badItemId: itemNameOrId, vaultId },
+        tip: [
+          'Double check the item in your 1password vault.',
+          'It is always safer to use IDs since they are more stable than names.',
+        ],
+      });
+    } else if (errMessage.includes(' does not have a field ')) {
+      // message includes `item 'dev test/example' does not have a field 'bad field name'`
+      const matches = errMessage.match(/item '([^']+)' does not have a field '([^']+)'/);
+      const itemNameOrId = matches?.[1] || 'unknown';
+      const [vaultId, itemId] = itemNameOrId.split('/');
+      const fieldNameOrId = matches?.[2]?.replace('.', '/') || 'unknown';
+
+      // const vaultNameOrId = errMessage.substring(1, errMessage.substring(1).indexOf('"') + 1);
+      return new ResolutionError(`1password vault "${vaultId}" item "${itemId}" does not have field "${fieldNameOrId}"`, {
+        code: 'BAD_FIELD_REFERENCE',
+        extraMetadata: { vaultId, itemId, badFieldId: fieldNameOrId },
+        tip: [
+          'Double check the field name/id in your item.',
+        ],
+        // TODO: add link to item?
+      });
     }
+
+
+
     // when the desktop app integration is not connected, some interactive CLI help is displayed
     // however if it dismissed, we get an error with no message
     // TODO: figure out the right workflow here?
     if (!errMessage) {
-      throw new ResolutionError('1password cli not configured', {
+      return new ResolutionError('1password cli not configured', {
         tip: [
           'By not using a service account token, you are relying on your local 1password cli installation and authentication.',
           'You many need to enable the 1password Desktop app integration, see https://developer.1password.com/docs/cli/get-started/#step-2-turn-on-the-1password-desktop-app-integration',
@@ -73,7 +115,154 @@ export async function execOpCliCommand(cmdArgs: Array<string>) {
         ],
       });
     }
-
-    throw new Error(`1password cli error - ${errMessage || 'unknown'}`);
+    return new Error(`1password cli error - ${errMessage || 'unknown'}`);
+  } else if ((err as any).code === 'ENOENT') {
+    return new ResolutionError('1password cli `op` not found', {
+      tip: [
+        'By not using a service account token, you are relying on your local 1password cli installation for ambient auth.',
+        'But your local 1password cli (`op`) was not found. Install it here - https://developer.1password.com/docs/cli/get-started/',
+      ],
+    });
+  } else {
+    return new ResolutionError(`Problem invoking 1password cli: ${(err as any).message}`);
   }
+}
+
+
+let opReadBatch: Record<string, { deferredPromises: Array<DeferredPromise<string>> }> | undefined;
+const BATCH_READ_TIMEOUT = 50;
+
+function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
+  debug('execute op read batch', Object.keys(batchToExecute));
+  const envMap = {} as Record<string, string>;
+  let i = 1;
+  Object.keys(batchToExecute).forEach((opReference) => {
+    envMap[`DMNO_1P_INJECT_${i++}`] = opReference;
+  });
+  const startAt = new Date();
+  // `env -0` splits values by a null character instead of newlines
+  // because otherwise we'll have trouble dealing with values that contain newlines
+  spawnAsync('op', 'run --no-masking -- env -0'.split(' '), {
+    env: {
+      // have to pass through at least path so it can find `op`, but might need other items too?
+      PATH: process.env.PATH!,
+      // ...process.env as any,
+      ...envMap,
+    },
+  })
+    .then((result) => {
+      debug(`batched OP request took ${+new Date() - +startAt}ms`);
+
+      const lines = result.split('\0');
+      for (const line of lines) {
+        const eqPos = line.indexOf('=');
+        const key = line.substring(0, eqPos);
+
+        if (!envMap[key]) continue;
+        const val = line.substring(eqPos + 1);
+        const opRef = envMap[key];
+
+        // resolve the deferred promises with the value
+        batchToExecute[opRef].deferredPromises.forEach((p) => {
+          p.resolve(val);
+        });
+      }
+    })
+    .catch((err) => {
+      // have to do special handling of errors because if any IDs are no good, it kills the whole request
+      const opErr = processOpCliError(err);
+      debug('batch failed', opErr);
+      if ((opErr as any).code === 'BAD_VAULT_REFERENCE') {
+        const badId = (opErr as any).extraMetadata.badVaultId;
+        debug('skipping failed bad vault id -', badId);
+        for (const opRef in batchToExecute) {
+          if (opRef.startsWith(`op://${badId}/`)) {
+            batchToExecute[opRef].deferredPromises.forEach((p) => {
+              p.reject(opErr);
+            });
+            delete batchToExecute[opRef];
+          }
+        }
+      } else if ((opErr as any).code === 'BAD_ITEM_REFERENCE') {
+        const badId = (opErr as any).extraMetadata.badItemId;
+        debug('skipping failed bad item id -', badId);
+        for (const opRef in batchToExecute) {
+          const itemRef = opRef.split('/')?.[3];
+          if (itemRef === badId) {
+            batchToExecute[opRef].deferredPromises.forEach((p) => {
+              p.reject(opErr);
+            });
+            delete batchToExecute[opRef];
+          }
+        }
+      } else if ((opErr as any).code === 'BAD_FIELD_REFERENCE') {
+        const badId = (opErr as any).extraMetadata.badFieldId;
+        debug('skipping failed bad field id -', badId);
+        for (const opRef in batchToExecute) {
+          const fieldRef = opRef.split('/')?.slice(4).join('/');
+          if (fieldRef === badId) {
+            batchToExecute[opRef].deferredPromises.forEach((p) => {
+              p.reject(opErr);
+            });
+            delete batchToExecute[opRef];
+          }
+        }
+      } else {
+        for (const opRef in batchToExecute) {
+          batchToExecute[opRef].deferredPromises.forEach((p) => {
+            p.reject(opErr);
+          });
+          delete batchToExecute[opRef];
+        }
+      }
+
+      if (Object.keys(batchToExecute).length) {
+        debug('re-executing remainder of batch', Object.keys(batchToExecute));
+        executeReadBatch(batchToExecute);
+      }
+    });
+}
+
+/**
+ * reads a single value from 1Password by reference (similar to `op read`)
+ * but internally batches requests and uses `op run`
+ * */
+export async function opCliRead(opReference: string) {
+  if (ENABLE_BATCHING) {
+  // if no batch exists, we'll create it, and this function will kick it off after a timeout
+    let shouldExecuteBatch = false;
+    if (!opReadBatch) {
+      opReadBatch = {};
+      shouldExecuteBatch = true;
+    }
+
+    // otherwise we'll just add to the existing batch
+    opReadBatch[opReference] ||= {
+      deferredPromises: [],
+    };
+
+    const deferred = createDeferredPromise<string>();
+    opReadBatch[opReference].deferredPromises.push(deferred);
+
+    if (shouldExecuteBatch) {
+      setTimeout(() => {
+        if (!opReadBatch) throw Error('expected to find op read batch!');
+        const batchToExecute = opReadBatch;
+        opReadBatch = undefined;
+        executeReadBatch(batchToExecute);
+      }, BATCH_READ_TIMEOUT);
+    }
+    return deferred.promise;
+  } else {
+    // fetch each item individually
+    const result = await execOpCliCommand(['read', '--force', '--no-newline', opReference]);
+    return result;
+  }
+}
+
+export function getIdsFromShareLink(opItemShareLinkUrl: string) {
+  const url = new URL(opItemShareLinkUrl);
+  const vaultId = url.searchParams.get('v')!;
+  const itemId = url.searchParams.get('i')!;
+  return { vaultId, itemId };
 }

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -1,0 +1,65 @@
+import { spawnSync } from 'node:child_process';
+import Debug from 'debug';
+import { ResolutionError } from 'dmno';
+
+
+const debug = Debug('dmno:1pass-plugin');
+
+export async function execOpCliCommand(cmdArgs: Array<string>) {
+  const startAt = new Date();
+  // using system-installed copy of `op`
+  const cmd = spawnSync('op', cmdArgs);
+  debug(`op cli command - "${cmdArgs}"`);
+  debug(`> took ${+new Date() - +startAt}ms`);
+  if (cmd.status === 0) {
+    return cmd.stdout.toString();
+  } else if (cmd.error) {
+    if ((cmd.error as any).code === 'ENOENT') {
+      throw new ResolutionError('1password cli `op` not found', {
+        tip: [
+          'By not using a service account token, you are relying on your local 1password cli installation for ambient auth.',
+          'But your local 1password cli (`op`) was not found. Install it here - https://developer.1password.com/docs/cli/get-started/',
+        ],
+      });
+    } else {
+      throw new ResolutionError(`Problem invoking 1password cli: ${cmd.error.message}`);
+    }
+  } else {
+    let errMessage = cmd.stderr.toString();
+    // get rid of "[ERROR] 2024/01/23 12:34:56 " before actual message
+    // console.log('1pass cli error', errMessage);
+    if (errMessage.startsWith('[ERROR]')) errMessage = errMessage.substring(28);
+    if (errMessage.includes('authorization prompt dismissed')) {
+      throw new ResolutionError('1password app authorization prompt dismissed by user', {
+        tip: [
+          'By not using a service account token, you are relying on your local 1password installation',
+          'When the authorization prompt appears, you must authorize/unlock 1password to allow access',
+        ],
+      });
+    } else if (errMessage.includes("isn't a vault in this account")) {
+      throw new ResolutionError('1password vault not found in account connected to op cli', {
+        tip: [
+          'By not using a service account token, you are relying on your local 1password cli installation and authentication.',
+          'The account currently connected to the cli does not contain (or have access to) the selected vault',
+          'This must be resolved in your terminal - try running `op whoami` to see which account is connected to your `op` cli.',
+          'You may need to call `op signout` and `op signin` to select the correct account.',
+        ],
+      });
+    }
+    // when the desktop app integration is not connected, some interactive CLI help is displayed
+    // however if it dismissed, we get an error with no message
+    // TODO: figure out the right workflow here?
+    if (!errMessage) {
+      throw new ResolutionError('1password cli not configured', {
+        tip: [
+          'By not using a service account token, you are relying on your local 1password cli installation and authentication.',
+          'You many need to enable the 1password Desktop app integration, see https://developer.1password.com/docs/cli/get-started/#step-2-turn-on-the-1password-desktop-app-integration',
+          'Try running `op whoami` to make sure the cli is connected to the correct account',
+          'You may need to call `op signout` and `op signin` to select the correct account.',
+        ],
+      });
+    }
+
+    throw new Error(`1password cli error - ${errMessage || 'unknown'}`);
+  }
+}

--- a/packages/plugins/1password/src/constants.ts
+++ b/packages/plugins/1password/src/constants.ts
@@ -1,0 +1,1 @@
+export const ONEPASS_ICON = 'simple-icons:1password';

--- a/packages/plugins/1password/src/data-types.ts
+++ b/packages/plugins/1password/src/data-types.ts
@@ -1,6 +1,6 @@
 import { DmnoBaseTypes, ValidationError, createDmnoDataType } from 'dmno';
 
-const ONEPASS_ICON = 'simple-icons:1password';
+import { ONEPASS_ICON } from './constants';
 
 const OnePasswordServiceAccountToken = createDmnoDataType({
   typeLabel: '1password/service-account-token',

--- a/packages/plugins/1password/src/index.ts
+++ b/packages/plugins/1password/src/index.ts
@@ -2,7 +2,7 @@
 
 export * from './data-types';
 export * from './plugin';
-
+export * from './override-loader';
 
 
 

--- a/packages/plugins/1password/src/override-loader.ts
+++ b/packages/plugins/1password/src/override-loader.ts
@@ -1,0 +1,89 @@
+import { DmnoOverrideLoader, OverrideSource, parsedDotEnvToObj } from 'dmno';
+import { parseDotEnvContents } from 'dmno/utils';
+import { ONEPASS_ICON } from './constants';
+import { execOpCliCommand } from './cli-helper';
+
+type OnePassLocation =
+  // reference includes a field already
+  { reference: string } |
+  // selecting by name is possible without a vault, but will throw an error if multiple items are found
+  { name: string, vault?: string, field?: string } |
+  { link: string, field?: string };
+
+function parseReference(reference: string) {
+  if (!reference.startsWith('op://')) {
+    throw new Error('Valid secret reference must start with "op://"');
+  }
+  const [vaultName, itemId, fieldName] = reference.substring(5).split('/'); // remove op://
+  return {
+    vaultName: vaultName === 'Employee' ? 'Private' : vaultName,
+    itemId,
+    fieldName,
+  };
+}
+
+async function getItemValue(loc: OnePassLocation, defaultFieldName?: string) {
+  let rawItemJson: string;
+
+  let fieldName: string | undefined;
+
+  // reference includes a field
+  if ('reference' in loc) {
+    const itemValue = await execOpCliCommand([
+      'read', loc.reference,
+    ]);
+    return itemValue;
+  } else if ('link' in loc) {
+    rawItemJson = await execOpCliCommand([
+      'item', 'get', loc.link,
+      '--format=json',
+    ]);
+    fieldName = loc.field || defaultFieldName;
+  } else if ('name' in loc) {
+    // TODO: handle error when no vault id is provided and more than 1 item is found
+    // TODO: also probably ok if zero items were found if looking up by name
+    rawItemJson = await execOpCliCommand([
+      'item', 'get', loc.name,
+      ...loc.vault ? [`--vault="${loc.vault}"`] : [],
+      '--format=json',
+    ]);
+    fieldName = loc.field || defaultFieldName;
+  } else {
+    throw new Error('invalid 1password location');
+  }
+  if (!fieldName) throw new Error('missing field name');
+
+  if (!rawItemJson) {
+    throw new Error('unable to fetch overrides from 1password');
+  }
+
+  const itemDetails = JSON.parse(rawItemJson);
+  const fieldDetails = itemDetails.fields.find((f: any) => f.label === fieldName);
+  return fieldDetails.value;
+}
+
+
+export function onePasswordOverrideLoader(
+  itemLocation: OnePassLocation,
+  // format = 'dotenv' // can add this if we want to support more formats later
+): DmnoOverrideLoader {
+  return {
+    async load(ctx) {
+      // console.log('start loading 1pass overrides');
+      // const start = +new Date();
+      const dotEnvStr = await getItemValue(itemLocation, ctx.serviceId);
+      const parsedDotEnv = parseDotEnvContents(dotEnvStr);
+      const envObj = parsedDotEnvToObj(parsedDotEnv);
+      // console.log('finished', +new Date() - start);
+
+      return [
+        new OverrideSource(
+          '1password .env',
+          '1pass item title?',
+          ONEPASS_ICON,
+          envObj,
+        ),
+      ];
+    },
+  };
+}

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process';
 import _ from 'lodash-es';
 import kleur from 'kleur';
 import {
@@ -9,14 +8,12 @@ import {
   PluginInputValue,
   inject,
 } from 'dmno';
-import Debug from 'debug';
 
 import { Client, createClient } from '@1password/sdk';
 
 import packageJson from '../package.json';
 import { OnePasswordTypes } from './data-types';
-
-const debug = Debug('dmno:1pass-plugin');
+import { execOpCliCommand } from './cli-helper';
 
 type FieldId = string;
 type ItemId = string;
@@ -24,65 +21,6 @@ type VaultId = string;
 type VaultName = string;
 type ReferenceUrl = string;
 type ServiceAccountToken = string;
-
-async function execOpCliCommand(cmdArgs: Array<string>) {
-  const startAt = new Date();
-  // using system-installed copy of `op`
-  const cmd = spawnSync('op', cmdArgs);
-  debug(`op cli command - "${cmdArgs}"`);
-  debug(`> took ${+new Date() - +startAt}ms`);
-  if (cmd.status === 0) {
-    return cmd.stdout.toString();
-  } else if (cmd.error) {
-    if ((cmd.error as any).code === 'ENOENT') {
-      throw new ResolutionError('1password cli `op` not found', {
-        tip: [
-          'By not using a service account token, you are relying on your local 1password cli installation for ambient auth.',
-          'But your local 1password cli (`op`) was not found. Install it here - https://developer.1password.com/docs/cli/get-started/',
-        ],
-      });
-    } else {
-      throw new ResolutionError(`Problem invoking 1password cli: ${cmd.error.message}`);
-    }
-  } else {
-    let errMessage = cmd.stderr.toString();
-    // get rid of "[ERROR] 2024/01/23 12:34:56 " before actual message
-    // console.log('1pass cli error', errMessage);
-    if (errMessage.startsWith('[ERROR]')) errMessage = errMessage.substring(28);
-    if (errMessage.includes('authorization prompt dismissed')) {
-      throw new ResolutionError('1password app authorization prompt dismissed by user', {
-        tip: [
-          'By not using a service account token, you are relying on your local 1password installation',
-          'When the authorization prompt appears, you must authorize/unlock 1password to allow access',
-        ],
-      });
-    } else if (errMessage.includes("isn't a vault in this account")) {
-      throw new ResolutionError('1password vault not found in account connected to op cli', {
-        tip: [
-          'By not using a service account token, you are relying on your local 1password cli installation and authentication.',
-          'The account currently connected to the cli does not contain (or have access to) the selected vault',
-          'This must be resolved in your terminal - try running `op whoami` to see which account is connected to your `op` cli.',
-          'You may need to call `op signout` and `op signin` to select the correct account.',
-        ],
-      });
-    }
-    // when the desktop app integration is not connected, some interactive CLI help is displayed
-    // however if it dismissed, we get an error with no message
-    // TODO: figure out the right workflow here?
-    if (!errMessage) {
-      throw new ResolutionError('1password cli not configured', {
-        tip: [
-          'By not using a service account token, you are relying on your local 1password cli installation and authentication.',
-          'You many need to enable the 1password Desktop app integration, see https://developer.1password.com/docs/cli/get-started/#step-2-turn-on-the-1password-desktop-app-integration',
-          'Try running `op whoami` to make sure the cli is connected to the correct account',
-          'You may need to call `op signout` and `op signin` to select the correct account.',
-        ],
-      });
-    }
-
-    throw new Error(`1password cli error - ${errMessage || 'unknown'}`);
-  }
-}
 
 // Typescript has some limitations around generics and how things work across parent/child classes
 // so unfortunately, we have to add some extra type annotations, but it's not too bad

--- a/packages/ts-lib/src/defer-promise.ts
+++ b/packages/ts-lib/src/defer-promise.ts
@@ -2,10 +2,10 @@
 // should be used sparingly
 export function createDeferredPromise<T = unknown>() {
   // set to noop, but they will be replaced immediately
-  let resolve: (value?: T) => void = () => {};
+  let resolve: (value?: T) => void = (() => {});
   let reject: (reason?: unknown) => void = () => {};
-  const promise = new Promise((_resolve, _reject) => {
-    resolve = _resolve;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve as any;
     reject = _reject;
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     lodash-es:
       specifier: ^4.17.21
       version: 4.17.21
+    modern-async:
+      specifier: ^2.0.4
+      version: 2.0.4
     svgo:
       specifier: ^3.2.0
       version: 3.3.2
@@ -89,6 +92,9 @@ importers:
       lodash-es:
         specifier: 'catalog:'
         version: 4.17.21
+      modern-async:
+        specifier: 'catalog:'
+        version: 2.0.4
       svgo:
         specifier: 'catalog:'
         version: 3.3.2
@@ -202,8 +208,8 @@ importers:
         specifier: ^0.30.12
         version: 0.30.12
       modern-async:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: 'catalog:'
+        version: 2.0.4
       node-forge:
         specifier: ^1.3.1
         version: 1.3.1
@@ -8510,8 +8516,8 @@ packages:
   modern-ahocorasick@1.0.1:
     resolution: {integrity: sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA==}
 
-  modern-async@2.0.0:
-    resolution: {integrity: sha512-Ta/oj3nQm2nEBU3VCADoeTEytjTpugrqdPk6qbbM1mJuLLUkm9541oWnszGmJHIOJmRjsPydKUj1AaDm4dlrlw==}
+  modern-async@2.0.4:
+    resolution: {integrity: sha512-89Ig+D/NQAFi39/oRUphkwdLb4qo/3Vl21TCMPZY3oCWGQQ+HqNJ1kyWknyAJ2rsiewL9OGBmpKA5bQ0PikkMg==}
 
   module-definition@5.0.1:
     resolution: {integrity: sha512-kvw3B4G19IXk+BOXnYq/D/VeO9qfHaapMeuS7w7sNUqmGaA6hywdFHMi+VWeR9wUScXM7XjoryTffCZ5B0/8IA==}
@@ -21560,7 +21566,7 @@ snapshots:
 
   modern-ahocorasick@1.0.1: {}
 
-  modern-async@2.0.0:
+  modern-async@2.0.4:
     dependencies:
       core-js-pure: 3.37.1
       nanoassert: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   "debug": "^4.3.4"
   "kleur": "^4.1.5"
   "lodash-es": "^4.17.21"
+  "modern-async": "^2.0.4"
   "svgo": "^3.2.0"
   "tsup": "^8.2.4"
   "typescript": "^5.5.4"


### PR DESCRIPTION
Overrides are used to feed additional values into the system that are not being set by the schema itself.  This is critical because many different secret storage engines will still require a "secret-zero" to access that data, and we must feed that secret zero in somehow. The most common case is loading actual env vars. On production systems, these will often be set by the platform itself - either in an automatic way, or after being set by the user in some UI/cli.

These overrides are always coming in as a set of values, and are applied using their names.

Currently dmno loads actual env vars (`process.env`) then dotenv files (with the whole cascade of env specific and .local files). This was a good start as it handles many cases, but for a while, I've wanted to refactor it into something more pluggable. You can imagine wanting to use toml/yaml/etc files instead of .env, or wanting to disable .env altogether.

This PR introduces that system of "override loaders" (avoiding the term "plugin" since it is used already) and extracts the current behaviour into 2 override loaders `processEnvOverrideLoader` and `dotEnvFileOverrideLoader`.

The user can now provide an array of these loaders in a service definition, and it will apply them in that order (earlier items in the array have more precedence). If nothing is specified, the current behaviour will still be applied (process.env > dotenv files). Users can use process.env env vars to toggle behaviour, and any false values will be filtered out. For example:

```ts
import { defineDmnoService, processEnvOverrideLoader, dotEnvFileOverrideLoader } from 'dmno';

export default defineDmnoService({
  overrides: [
    processEnvOverrideLoader(),
    // only apply dotenv files if running locally
    process.env.NODE_ENV === 'development' && dotEnvFileOverrideLoader(),
  ],
  //...
```

## 1password Override Loader
This PR also introduces a new 1password-based override loader, which will load a dotenv style blob from a 1password item as overrides. Thanks to @Inlustra for the suggestion / feature request.

In his case, he has large sets of env vars he wants to share with team members, but this could also be useful for others to avoid having a .env file with potentially sensitive secrets sitting in plaintext. In this case, where we cannot select a single 1password item using ID/reference/links, we can search by name - so each team member could have their own item in their personal/employee vault with the same name.

### Loader DX
This 1password override loader must be pointed at a specific item+field in 1password. You can use a reference, a link, or search using field name (and optionally vault). While secrets point all the way to a specific field, for the other options, you 
can pass in a field name/label, or it will default to using the service name.

Note that the search by name option is particularly useful for personal overrides, since each team member will have their own item (usually in their own personal vault) and we cannot use a static id/path. The use can specify a vault name, but if none is set, it will search across all vaults. If more than one is found, it will throw an error.

This should let users organize things however they like, but I imagine a common way would be storing overrides for an app in a single item, and using a field for each service.


- `onePasswordOverrideLoader({ reference: 'op://Employee/dmno-local-dev-overrides/api' })` (already includes field)
- `onePasswordOverrideLoader({ name: 'my-app-dev-overrides' })` // will search all vaults
- `onePasswordOverrideLoader({ name: 'my-app-dev-overrides', vault: 'team-shared-secrets' })` // vault can be specified with name or ID
- `onePasswordOverrideLoader({ name: 'my-app-dev-overrides' })` // field will default to current service name
- `onePasswordOverrideLoader({ name: 'my-app-dev-overrides', field: 'api' })` // but can be overriden
- `onePasswordOverrideLoader({ link: 'https://start.1password.com/open/i?a=I3GUA2KU6BD3FBHA47QNBIVEV4&v=kcrmq4zkss7bg3lhfdh362ee2u&i=oeimpxnzjwyak5emnr547apt6a&h=dmnoinc.1password.com' })` (same field behaviour as name)

### 1password considerations

Note that this relies on the 1pass CLI (not the SDK) and your personal access. It does not make as much sense with a service account token, as we'd now have another bit of sensitive data we need to feed into the system somehow. We currently do this for plugins via the schema itself, which introduces a chicken/egg problem. We can't resolve the config until we have loaded the overrides...

~~Discovered a bug around the "Employee" vault and have [reported it to 1pass]`~~
_latest CLI fixes the previously found bug_

Currently it takes 500-800ms to load the overrides from 1password. Not so bad, but in a big multi-service system and potentially with 2 sets of overrides for each, this could add up. We can't really cache anything, since we'd need to cache that data securely, and we really want updated override values to take effect immediately.

If we try to fetch an item and it doesnt exist, we probably usually should throw an error. But in the search by name case for personal overrides, it seems possible that nothing will be found. Seems like this should either not throw, or at least have an option to not throw.