### PR TITLE
Infisical plugin and docs cleanup

### DIFF
--- a/.changeset/angry-shoes-poke.md
+++ b/.changeset/angry-shoes-poke.md
@@ -1,0 +1,5 @@
+---
+"@dmno/infisical-plugin": patch
+---
+
+New plugin to fetch secrets from Infisical

--- a/example-repo/.dmno/config.mts
+++ b/example-repo/.dmno/config.mts
@@ -1,6 +1,7 @@
 import { DmnoBaseTypes, defineDmnoService, configPath, NodeEnvType, switchBy, inject } from 'dmno';
 import { OnePasswordDmnoPlugin, OnePasswordTypes } from '@dmno/1password-plugin';
 import { BitwardenSecretsManagerDmnoPlugin, BitwardenSecretsManagerTypes } from '@dmno/bitwarden-plugin';
+import { InfisicalDmnoPlugin, InfisicalTypes } from '@dmno/infisical-plugin';
 import { EncryptedVaultDmnoPlugin, EncryptedVaultTypes } from '@dmno/encrypted-vault-plugin';
 
 
@@ -16,6 +17,10 @@ const OnePassSecretsDev = new OnePasswordDmnoPlugin('1pass', {
 });
 
 const BitwardenPlugin = new BitwardenSecretsManagerDmnoPlugin('bitwarden');
+
+const InfisicalPlugin = new InfisicalDmnoPlugin('infisical', {
+  environment: 'dev',
+});
 
 const EncryptedVaultSecrets = new EncryptedVaultDmnoPlugin('vault/prod', { name: 'prod', key: inject() });
 // const NonProdVault = new EncryptedVaultDmnoPlugin('vault/dev', {
@@ -37,7 +42,24 @@ export default defineDmnoService({
       typeDescription: 'standardized environment flag set by DMNO',
       value: (ctx) => ctx.get('NODE_ENV'),
     },
-    
+    INFISICAL_CLIENT_ID: {
+      extends: InfisicalTypes.clientId,
+    },
+    INFISICAL_CLIENT_SECRET: {
+      extends: InfisicalTypes.clientSecret,
+    },
+    INFISICAL_PROJECT_ID: {
+      extends: InfisicalTypes.projectId,
+    },
+    TEST_KEY_ALL_ENVS: {
+      value: InfisicalPlugin.secret(),
+    },
+    DEV_ONLY: {
+      value: InfisicalPlugin.secret(),
+    },
+    // PROD_ONLY: {
+    //   value: InfisicalPlugin.secret(),
+    // },
     REDACT_TEST: {
       sensitive: true,
       value: 'a a a a b b b b c c c c d d d',

--- a/example-repo/.dmno/config.mts
+++ b/example-repo/.dmno/config.mts
@@ -57,9 +57,6 @@ export default defineDmnoService({
     DEV_ONLY: {
       value: InfisicalPlugin.secret(),
     },
-    // PROD_ONLY: {
-    //   value: InfisicalPlugin.secret(),
-    // },
     REDACT_TEST: {
       sensitive: true,
       value: 'a a a a b b b b c c c c d d d',

--- a/example-repo/package.json
+++ b/example-repo/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@dmno/1password-plugin": "link:../packages/plugins/1password",
     "@dmno/bitwarden-plugin": "link:../packages/plugins/bitwarden",
+    "@dmno/infisical-plugin": "link:../packages/plugins/infisical",
     "dmno": "link:../packages/core",
     "@dmno/encrypted-vault-plugin": "link:../packages/plugins/encrypted-vault"
   }

--- a/example-repo/pnpm-lock.yaml
+++ b/example-repo/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@dmno/encrypted-vault-plugin':
         specifier: link:../packages/plugins/encrypted-vault
         version: link:../packages/plugins/encrypted-vault
+      '@dmno/infisical-plugin':
+        specifier: link:../packages/plugins/infisical
+        version: link:../packages/plugins/infisical
       dmno:
         specifier: link:../packages/core
         version: link:../packages/core
@@ -249,7 +252,7 @@ importers:
         version: 8.4.40
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.7(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4))
+        version: 3.4.7(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4))
       typescript:
         specifier: ^5.4.5
         version: 5.5.4
@@ -298,7 +301,7 @@ importers:
         version: link:../../../packages/integrations/remix
       '@remix-run/dev':
         specifier: ^2.10.3
-        version: 2.10.3(@remix-run/react@2.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.3(typescript@5.5.4))(@types/node@20.14.13)(terser@5.31.3)(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.13)(terser@5.31.3))
+        version: 2.10.3(@remix-run/react@2.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.3(typescript@5.5.4))(@types/node@20.14.13)(terser@5.31.3)(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.13)(terser@5.31.3))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -340,7 +343,7 @@ importers:
         version: 8.4.40
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.7(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4))
+        version: 3.4.7(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4))
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -8932,7 +8935,7 @@ snapshots:
 
   '@prisma/engines@4.16.2': {}
 
-  '@remix-run/dev@2.10.3(@remix-run/react@2.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.3(typescript@5.5.4))(@types/node@20.14.13)(terser@5.31.3)(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.13)(terser@5.31.3))':
+  '@remix-run/dev@2.10.3(@remix-run/react@2.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.3(typescript@5.5.4))(@types/node@20.14.13)(terser@5.31.3)(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4))(typescript@5.5.4)(vite@5.3.5(@types/node@20.14.13)(terser@5.31.3))':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/generator': 7.25.0
@@ -8976,7 +8979,7 @@ snapshots:
       pidtree: 0.6.0
       postcss: 8.4.40
       postcss-discard-duplicates: 5.1.0(postcss@8.4.40)
-      postcss-load-config: 4.0.2(postcss@8.4.40)(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.40)(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4))
       postcss-modules: 6.0.0(postcss@8.4.40)
       prettier: 2.8.8
       pretty-ms: 7.0.1
@@ -14316,7 +14319,7 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.40
 
-  postcss-load-config@4.0.2(postcss@8.4.40)(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.4.40)(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.0
@@ -15376,7 +15379,7 @@ snapshots:
 
   system-architecture@0.1.0: {}
 
-  tailwindcss@3.4.7(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4)):
+  tailwindcss@3.4.7(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -15395,7 +15398,7 @@ snapshots:
       postcss: 8.4.40
       postcss-import: 15.1.0(postcss@8.4.40)
       postcss-js: 4.0.1(postcss@8.4.40)
-      postcss-load-config: 4.0.2(postcss@8.4.40)(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.40)(ts-node@10.9.2(@swc/core@1.7.3(@swc/helpers@0.5.5))(@types/node@20.14.13)(typescript@5.5.4))
       postcss-nested: 6.2.0(postcss@8.4.40)
       postcss-selector-parser: 6.1.1
       resolve: 1.22.8

--- a/packages/docs-site/astro.config.ts
+++ b/packages/docs-site/astro.config.ts
@@ -141,6 +141,10 @@ export default defineConfig({
               link: '/docs/guides/multi-env/',
             },
             {
+              label: 'Secret Segmentation',
+              link: '/docs/guides/secret-segmentation/',
+            },
+            {
               label: 'Dynamic vs Static Config',
               link: '/docs/guides/dynamic-config/',
             },
@@ -172,6 +176,10 @@ export default defineConfig({
             {
               label: 'Bitwarden',
               link: '/docs/plugins/bitwarden/',
+            },
+            {
+              label: 'Infisical',
+              link: '/docs/plugins/infisical/',
             },
           ],
         }, {

--- a/packages/docs-site/src/content/docs/docs/guides/secret-segmentation.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/secret-segmentation.mdx
@@ -1,0 +1,30 @@
+---
+title: Secret segmentation
+description: Learn how to use DMNO's plugin instances to manage secrets for different environments or services.
+---
+
+There are many ways to segment secrets in DMNO. The most common is via [plugin instances](/docs/plugins/overview/#multiple-plugin-instances). This allows you to create a separate instance for each environment or service, giving you full control over which secrets are used where.
+
+In general, you should apply the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) when it comes to secrets. The facets of this are different for each organization, but as a rule of thumb, you should aim to:
+- Minimize the number of people who have access to secrets, and regularly review and audit who does
+- Minimize the environments (e.g., dev, staging, production) and their associated machine identities that have access to secrets
+- Rotate secrets whenever possible
+- Use short-lived credentials whenever possible
+
+## Sample setups
+
+Asuming something resembling a trunk-based workflow (i.e., you have a single production environment and are using feature flags to manage changes across environments), the minimum viable setup that we recommend looks something like this: 
+- a plugin instance for dev secrets - those that are necessary for local development and any shared dev services
+- a plugin instance for prod secrets - those that are necessary for production services
+
+The next step would be split out those plugin instances per service in each environment. For example, say your application has a `web` service and a `backend` service. You would then create `web-dev`,`web-prod`, `backend-dev`, and `backend-prod` plugin instances.
+
+We're not advocating for these as optimal setups for all applications, but they're a good starting point. The more you can apply the principle of least privilege, the better.
+
+
+
+
+
+
+
+

--- a/packages/docs-site/src/content/docs/docs/guides/secret-segmentation.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/secret-segmentation.mdx
@@ -13,7 +13,7 @@ In general, you should apply the [principle of least privilege](https://en.wikip
 
 ## Sample setups
 
-Asuming something resembling a trunk-based workflow (i.e., you have a single production environment and are using feature flags to manage changes across environments), the minimum viable setup that we recommend looks something like this: 
+Assuming something resembling a trunk-based workflow (i.e., you have a single production environment and are using feature flags to manage changes across environments), the minimum viable setup that we recommend looks something like this: 
 - a plugin instance for dev secrets - those that are necessary for local development and any shared dev services
 - a plugin instance for prod secrets - those that are necessary for production services
 

--- a/packages/docs-site/src/content/docs/docs/plugins/1password.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/1password.mdx
@@ -43,7 +43,7 @@ export default defineDmnoService({
 :::tip[Plugin instance IDs]
 You must give each plugin instance a unique id so we can refer to it in other services and the [`dmno` CLI](/docs/reference/cli/plugin/).
 
-See [Segmenting secrets](/docs/guides/segmenting-secrets/) for more details.
+See [Segmenting secrets](/docs/guides/secret-segmentation/) for more details.
 :::
 
 

--- a/packages/docs-site/src/content/docs/docs/plugins/1password.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/1password.mdx
@@ -43,18 +43,8 @@ export default defineDmnoService({
 :::tip[Plugin instance IDs]
 You must give each plugin instance a unique id so we can refer to it in other services and the [`dmno` CLI](/docs/reference/cli/plugin/).
 
-In this case we used `1pass`, but you can imagine splitting vaults and access, and having multiple plugin instances - for example `1pass/prod` for highly sensitive production secrets and `1pass/dev` for everything else.
+See [Segmenting secrets](/docs/guides/segmenting-secrets/) for more details.
 :::
-
-### Injecting the plugin in monorepo services
-In a monorepo, you are likely managing secrets for multiple services. If you will be using the same service account(s) to access those secrets, you can initialize a plugin instance once in your root service as seen above, and then _inject_ it in child services. Note we must use that same id we set during initialization.
-
-```typescript title='apps/some-service/.dmno/config.mts'
-import { OnePasswordDmnoPlugin } from '@dmno/1password-plugin';
-
-// 💉 inject the already initialized plugin instead of re-initializing it
-const onePassSecrets = OnePasswordDmnoPlugin.injectInstance('1pass');
-```
 
 
 ------------
@@ -78,13 +68,7 @@ If you already use 1password and your secrets live in a vault that holds other i
 
 </Steps>
 
-This service account token will now serve as your "secret-zero" - which grants access to the rest of your sensitive config stored in 1Password. It must be set locally (unless relying on cli-based auth) and in deployed environments. It is sensitive so we must pass in the value as an _override_ rather than storing it within the config. Locally this usually means storing it in your [`.env.local` file](/docs/guides/env-files/) and on a deployed environment you'll usually set it within some kind of UI, wherever you would normally pass in environment variables.
-
-```diff title=".dmno/.env.local"
-+OP_TOKEN=ops_abc123...
-```
-
-Note that the config path of `OP_TOKEN` is arbitrary and you can see how it was wired up from your config schema to the plugin input in the example above. If you are using multiple vaults and service accounts, you may have something more like `OP_TOKEN_PROD` and `OP_TOKEN_DEV`.
+This service account token will now serve as your _secret-zero_ - which grants access to the rest of your sensitive config stored in 1Password. It must be set locally (unless relying on cli-based auth) and in any deployed environments. It is sensitive so we must pass in the value as an _override_ rather than storing it within the config. See [Setting overrides](/docs/guides/env-files/#setting-overrides-via-env-files) for more details.
 
 :::tip[Vault organization best practices]
 Consider how you want to organize your vaults and service accounts, keeping in mind [best practices](https://support.1password.com/business-security-practices/#access-management-and-the-principle-of-least-privilege). At a minimum, DMNO recommends having a vault for highly sensitive production secrets and another for everything else.
@@ -242,16 +226,9 @@ Field IDs are not easy to get from the 1Password UI. Luckily when the supplied f
 The secret reference for invidivual fields within an item can be found by clicking on the down arrow icon **on the field** and selecting `Copy Secret Reference`.
 :::
 
-## Caching
-In order to avoid rate limits and keep dev server restarts extremely fast, we heavily cache data fetched from external sources. After updating secrets in 1password, if the item has been cached, you'll need to clear the cache to see it take effect.
-
-- Use the [`dmno clear-cache` command](/docs/reference/cli/clear-cache/) to clear the cache once
-- The [`dmno resolve`](/docs/reference/cli/resolve/) and [`dmno run`](/docs/reference/cli/run/) commands have cache related flags:
-  - `--skip-cache` - skips caching logic altogether
-  - `--clear-cache` - clears the cache once before continuing as normal
 
 :::tip[Active config iteration]
 While you are actively working on the config itself, `dmno resolve -w --skip-cache` will combine watch mode with skipping cache logic.
 
-Once you are satisfied, _clear_ the cache once more and you are good to go.
+See [caching](/docs/plugins/overview/#caching) for more details.
 :::

--- a/packages/docs-site/src/content/docs/docs/plugins/bitwarden.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/bitwarden.mdx
@@ -46,16 +46,6 @@ You must give each plugin instance a unique id so we can refer to it in other se
 In this case we used `bitwarden`, but you can imagine splitting vaults and access, and having multiple plugin instances - for example `bitwarden/prod` for highly sensitive production secrets and `bitwarden/dev` for everything else.
 :::
 
-### Injecting the plugin in monorepo services
-In a monorepo, you are likely managing secrets for multiple services. If you will be using the same service account(s) to access those secrets, you can initialize a plugin instance once in your root service as seen above, and then inject it in child services. Note we must use that same id we set during initialization.
-
-```typescript title='apps/some-service/.dmno/config.mts'
-import { BitwardenSecretsManagerDmnoPlugin } from '@dmno/bitwarden-plugin';
-
-// 💉 inject the already initialized plugin instead of re-initializing it
-const bitwardenPlugin = BitwardenSecretsManagerDmnoPlugin.injectInstance('bitwarden');
-```
-
 
 ------------
 
@@ -64,34 +54,12 @@ const bitwardenPlugin = BitwardenSecretsManagerDmnoPlugin.injectInstance('bitwar
 If you are already using Bitwarden Secrets Manager, you likely already have existing [projects](https://bitwarden.com/help/projects/) that contain [secrets](https://bitwarden.com/help/secrets/). If so, now would be a good time to review how they are all organized. If not, you should create at least one project, as each secret can have a parent project it belongs to, and access can be granted to projects rather than managing each secret individually.
 
 :::tip[Use projects to segment access]
-You should use multiple projects to segment your secrets following the [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege). This means at minimum, you should have one project for ultra-sensitive production secrets, and another for everything else. How much more you want to break things up is up to you and will depend on your security requirements.
-
-It is technically possible to create secrets without using projects and/or to assign permissions at the individual secret level, but we do not recommend it.
+You should use multiple projects to segment your secrets following the [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege). See more in our [Secret segmentation](/docs/guides/secret-segmentation/) guide.
 :::
 
-## Setup Machine Account & Access Tokens
 
-Machine accounts can be granted access to projects, and each machine account can have multiple access tokens with optional expiration. How you want to manage this is up to you, but a sensible approach could be:
+Machine account access tokens now serve as your _secret-zero_ - which grants access to the rest of your sensitive config stored in Bitwarden. It must be set locally and in deployed environments, but it is sensitive so we must pass in the value as an _override_ rather than storing it within the config. Locally, this usually means storing it in your [`.env.local` file](/docs/guides/env-files/) and on a deployed environment you'll usually set it wherever you would normally pass in environment variables. DMNO will handle the rest. See [Setting overrides](/docs/guides/env-files/#setting-overrides-via-env-files) for more details.
 
-- Production machine account has access to all projects
-  - single access token is used at a time
-- Staging/CI machine account has access to all projects except ultra-sensitive prod secrets
-  - each environment/CI/external tool could have a unique access token
-- Dev machine account has access to secrets needed for local dev
-  - each developer could have a unique access token
-
-Expiring tokens are more secure, but require the overhead of rolling those tokens, which must be done manually. Not wanting to cause an outage, you may want to roll them manually without the pressure of a potentially forgotten expiry date. To roll without downtime, create a new token, redeploy, and then decommission the previous token.
-
-### 
-
-
-Machine account access tokens now serve as your _secret-zero_ - which grants access to the rest of your sensitive config stored in Bitwarden. It must be set locally and in deployed environments, but it is sensitive so we must pass in the value as an _override_ rather than storing it within the config. Locally, this usually means storing it in your [`.env.local` file](/docs/guides/env-files/) and on a deployed environment you'll usually set it within some kind of UI, wherever you would normally pass in environment variables.
-
-```diff title=".dmno/.env.local"
-+BWS_TOKEN=0.abc123...
-```
-
-Note that the config path of `BWS_TOKEN` is arbitrary and you can see how it was wired up from your config schema to the plugin input in the example above.
 
 ------
 

--- a/packages/docs-site/src/content/docs/docs/plugins/bitwarden.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/bitwarden.mdx
@@ -119,21 +119,6 @@ export default defineDmnoService({
 });
 ```
 
-## Caching
-In order to avoid rate limits and keep dev server restarts extremely fast, we heavily cache data fetched from external sources. After updating secrets in Bitwarden, if the item has been cached, you'll need to clear the cache to see it take effect.
-
-- Use the [`dmno clear-cache` command](/docs/reference/cli/clear-cache/) to clear the cache once
-- The [`dmno resolve`](/docs/reference/cli/resolve/) and [`dmno run`](/docs/reference/cli/run/) commands have cache related flags:
-  - `--skip-cache` - skips caching logic altogether
-  - `--clear-cache` - clears the cache once before continuing as normal
-
-:::tip[Active config iteration]
-While you are actively working on the config itself, `dmno resolve -w --skip-cache` will combine watch mode with skipping cache logic.
-
-Once you are satisfied, clear the cache once more and you are good to go.
-:::
-
-
 ## Self-hosted
 In case you are self-hosting Bitwarden Secrets Manager, the `BitwardenSecretsManagerDmnoPlugin` also takes additional inputs for `apiServerUrl` and `identityServerUrl`. The values for this can be found in the Bitwarden UI under `Machine Accounts` > `Config`. See the [Bitwarden docs](https://bitwarden.com/help/machine-accounts/#configuration-information) for more details.
 

--- a/packages/docs-site/src/content/docs/docs/plugins/infisical.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/infisical.mdx
@@ -20,10 +20,10 @@ Install the package in the service(s) that will use secrets from Infisical.
 After installation, you'll need to initialize the plugin in your `config.mts` and add a few config items that are necessary to authenticate with Infisical and fetch secrets. It's ok if you have not created the machine identity or client keys - we'll do that in the next section.
 
 ```diff lang="ts" title='.dmno/config.mts'
-import { InfisicalSecretsManagerDmnoPlugin, InfisicalSecretsManagerTypes } from '@dmno/infisical-plugin';
+import { InfisicalDmnoPlugin, InfisicalTypes } from '@dmno/infisical-plugin';
 
 // explicitly wire the plugin instance to the config path
-const infisicalPlugin = new InfisicalSecretsManagerDmnoPlugin('infisical/dev', {
+const infisicalPlugin = new InfisicalDmnoPlugin('infisical/dev', {
   environment: 'development',
   clientId: configPath('..', 'INFISICAL_CLIENT_ID'),
   clientSecret: configPath('..', 'INFISICAL_CLIENT_SECRET'),
@@ -31,7 +31,7 @@ const infisicalPlugin = new InfisicalSecretsManagerDmnoPlugin('infisical/dev', {
 });
 
 // or you can inject by default
-const infisicalPlugin2 = new InfisicalSecretsManagerDmnoPlugin('infisical/prod', {
+const infisicalPlugin2 = new InfisicalDmnoPlugin('infisical/prod', {
   environment: 'production',
 }); 
 
@@ -58,7 +58,7 @@ See our [General plugin guidelines](/docs/plugins/overview/#general-plugin-guide
 
 ### Project & secrets
 
-If you are already using Infisical, you probably already have existing projects and secrets. If not, you should create at least one [project](https://infisical.com/docs/documentation/platform/project). Infisical uses the concept of [environments](https://infisical.com/docs/documentation/platform/project#project-environments) to group secrets. Make sure to make your secrets available in the same environment configuration as each plugin instance.
+If you are an existing Infisical user, you probably already have projects and secrets. If not, you should create at least one [project](https://infisical.com/docs/documentation/platform/project). Infisical uses the concept of [environments](https://infisical.com/docs/documentation/platform/project#project-environments) to group secrets. Make sure to make your secrets available in the same environment configuration as each plugin instance.
 
 ### Machine identity & client keys
 
@@ -75,9 +75,9 @@ Also note that the **Client Secret** is highly sensitive and should be treated a
 The Infisical plugin provides one method for fetching secrets, based on the name of the secret. The name itself will be inferred from the config item name. You can optionally pass a name if you wish to override the default.
 
 ```typescript title='.dmno/config.mts'
-import { InfisicalSecretsManagerDmnoPlugin, InfisicalSecretsManagerTypes } from '@dmno/infisical-plugin';
+import { InfisicalDmnoPlugin, InfisicalTypes } from '@dmno/infisical-plugin';
 
-const infisicalPlugin = new InfisicalSecretsManagerDmnoPlugin('infisical/dev', {
+const infisicalPlugin = new InfisicalDmnoPlugin('infisical/dev', {
   environment: 'development',
 });
 
@@ -85,12 +85,25 @@ export default defineDmnoService({
   schema: {
     SOME_SECRET: {
       // this will fetch the secret with the name 'SOME_SECRET' from the project specified in the plugin instance
-      value: InfisicalPlugin.secret(),
+      value: infisicalPlugin.secret(),
     },
     SOME_NEW_SECRET: {
       // this will fetch the secret with the name 'SOME_OTHER_SECRET' and make it available as SOME_NEW_SECRET in your DMNO_CONFIG
-      value: InfisicalPlugin.secret('SOME_OTHER_SECRET'),
+      value: infisicalPlugin.secret('SOME_OTHER_SECRET'),
     },
   },
+});
+```
+
+### Self-hosted Infisical
+
+If you are using a self-hosted version of Infisical, the `InfisicalDmnoPlugin` takes an optional `siteUrl` parameter. For example:
+
+```typescript title='.dmno/config.mts'
+import { InfisicalDmnoPlugin, InfisicalTypes } from '@dmno/infisical-plugin';
+
+const infisicalPlugin = new InfisicalDmnoPlugin('infisical/dev', {
+  environment: 'development',
+  siteUrl: 'https://infisical.mycompany.com',
 });
 ```

--- a/packages/docs-site/src/content/docs/docs/plugins/infisical.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/infisical.mdx
@@ -1,0 +1,96 @@
+---
+title: Infisical plugin
+description: DMNO's Infisical plugin allows you to securely access your secrets stored in Infisical.
+npmPackage: "@dmno/infisical-plugin"
+---
+
+import { Steps, Icon } from '@astrojs/starlight/components';
+import TabbedCode from '@/components/TabbedCode.astro';
+
+This DMNO plugin allows you to securely access your secrets stored in [Infisical](https://infisical.com/). The current implementation uses [Machine Identities](https://infisical.com/docs/documentation/platform/identities/machine-identities#machine-identities) and [Universal Auth](https://infisical.com/docs/documentation/platform/identities/universal-auth#universal-auth). If you need to use a different authentication method, please [open an issue](https://github.com/dmnojs/dmno/issues) and we can discuss options.
+
+## DMNO installation & setup
+
+Install the package in the service(s) that will use secrets from Infisical.
+
+<TabbedCode packageName="@dmno/infisical-plugin" />
+
+-----
+
+After installation, you'll need to initialize the plugin in your `config.mts` and add a few config items that are necessary to authenticate with Infisical and fetch secrets. It's ok if you have not created the machine identity or client keys - we'll do that in the next section.
+
+```diff lang="ts" title='.dmno/config.mts'
+import { InfisicalSecretsManagerDmnoPlugin, InfisicalSecretsManagerTypes } from '@dmno/infisical-plugin';
+
+// explicitly wire the plugin instance to the config path
+const infisicalPlugin = new InfisicalSecretsManagerDmnoPlugin('infisical/dev', {
+  environment: 'development',
+  clientId: configPath('..', 'INFISICAL_CLIENT_ID'),
+  clientSecret: configPath('..', 'INFISICAL_CLIENT_SECRET'),
+  projectId: configPath('..', 'INFISICAL_PROJECT_ID'),
+});
+
+// or you can inject by default
+const infisicalPlugin2 = new InfisicalSecretsManagerDmnoPlugin('infisical/prod', {
+  environment: 'production',
+}); 
+
+export default defineDmnoService({
+  schema: {
+    // ...
+    INFISICAL_CLIENT_ID: { extends: InfisicalTypes.clientId },
+    INFISICAL_CLIENT_SECRET: { extends: InfisicalTypes.clientSecret },
+    INFISICAL_PROJECT_ID: { extends: InfisicalTypes.projectId },
+    // ...
+  },
+});
+```
+
+:::tip[Wiring up plugin instances]
+
+See our [General plugin guidelines](/docs/plugins/overview/#general-plugin-guidelines) for more information on how to wire up plugin instances.
+
+:::
+
+------------
+
+## Infisical setup 
+
+### Project & secrets
+
+If you are already using Infisical, you probably already have existing projects and secrets. If not, you should create at least one [project](https://infisical.com/docs/documentation/platform/project). Infisical uses the concept of [environments](https://infisical.com/docs/documentation/platform/project#project-environments) to group secrets. Make sure to make your secrets available in the same environment configuration as each plugin instance.
+
+### Machine identity & client keys
+
+Next, you'll need to create a [Machine Identity](https://infisical.com/docs/documentation/platform/identities/machine-identities#concept) in your **Organization** under **Access Control**.  Make note of the **Client ID** and create a new **Client Secret**. Then in your project, make sure the identity you created has the necessary access. This is configured in the project settings under the **Access Control** -> **Machine Identities** tab.
+
+How you want to segment your identities and secrets is up to you. You could create a separate identity and secrets for each environment, or each service, or each project. At minimum, we recommend segmenting your production and non-production secrets. See [Secret Segmentation](/docs/guides/secret-segmentation/) for more details.
+
+Also note that the **Client Secret** is highly sensitive and should be treated as your _secret zero_. It will need to be set locally and passed in as an override. Locally, it can be set in your `.env.local` file, and in any deployed environments it can be set however you normally set environment variables for that platform. DMNO will handle the rest. See [Setting overrides](/docs/guides/env-files/#setting-overrides-via-env-files) for more details.
+
+------------
+
+## Adding items to your schema
+
+The Infisical plugin provides one method for fetching secrets, based on the name of the secret. The name itself will be inferred from the config item name. You can optionally pass a name if you wish to override the default.
+
+```typescript title='.dmno/config.mts'
+import { InfisicalSecretsManagerDmnoPlugin, InfisicalSecretsManagerTypes } from '@dmno/infisical-plugin';
+
+const infisicalPlugin = new InfisicalSecretsManagerDmnoPlugin('infisical/dev', {
+  environment: 'development',
+});
+
+export default defineDmnoService({
+  schema: {
+    SOME_SECRET: {
+      // this will fetch the secret with the name 'SOME_SECRET' from the project specified in the plugin instance
+      value: InfisicalPlugin.secret(),
+    },
+    SOME_NEW_SECRET: {
+      // this will fetch the secret with the name 'SOME_OTHER_SECRET' and make it available as SOME_NEW_SECRET in your DMNO_CONFIG
+      value: InfisicalPlugin.secret('SOME_OTHER_SECRET'),
+    },
+  },
+});
+```

--- a/packages/docs-site/src/content/docs/docs/plugins/overview.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/overview.mdx
@@ -12,6 +12,96 @@ Our first set of plugins are designed to help you manage secrets:
 - [**DMNO Encrypted Secrets Plugin**](/docs/plugins/encrypted-vault/): Store secrets securely in an encrypted vault file that you check in to your git repo. 
 - [**DMNO 1Password Plugin**](/docs/plugins/1password/): Securely pull secrets from [1Password](https://1password.com/)
 - [**DMNO Bitwarden Secrets Manager Plugin**](/docs/plugins/bitwarden/): Securely pull secrets from [Bitwarden Secrets Manager](https://bitwarden.com/products/secrets-manager/)
+- [**DMNO Infisical Plugin**](/docs/plugins/infisical/): Securely pull secrets from [Infisical](https://infisical.com/)
+
+## General plugin guidelines
+
+### Plugin inputs
+
+In general, plugins are initialized with a set of inputs that are used to configure the plugin. These inputs usually live in the `schema` of the DMNO service where the plugin is initialized. While the exact inputs will vary by plugin, they will often include some combination of:
+
+- Sensitive values that are needed to access the plugin's service
+- Non-sensitive values that are needed to configure the plugin
+
+Because plugins are typically used to access sensitive items themselves, this introduces a slight chicken-and-egg problem. In this case, DMNO allows you to define the plugin inputs in the `schema` but not provide a value. The sensitive value is then set via an _override_. 
+
+:::tip[More on overrides]
+For more on how overrides work and how to use them, see the [Setting overrides via `.env` files](https://dmno.dev/docs/guides/env-files/#setting-overrides-via-env-files).
+:::
+
+### Wiring up the inputs
+
+Because DMNO provides plugin-specific types, we can automatically inject the correct type for the plugin input. This means you don't need to manually wire up the inputs when you initialize the plugin. Our config engine will do this for you. 
+
+For example: 
+
+```ts
+import { SomePlugin, SomePluginTypes } from '@dmno/some-plugin';
+
+// by default, access token will be injected using types
+const somePluginInstance = new SomePlugin('some-plugin');
+
+// or you can explicitly wire it up by path
+const somePluginInstance2 = new SomePlugin('some-plugin', {
+  someToken: configPath('..', 'SOME_TOKEN'),
+  someOtherToken: configPath('..', 'SOME_OTHER_TOKEN'),
+});
+
+export default defineDmnoService({
+  schema: {
+    SOME_TOKEN: {
+      // this type allows us to inject the correct value from the config item
+      extends: SomePluginTypes.someToken,
+    },
+    SOME_OTHER_TOKEN: {
+      extends: SomePluginTypes.someOtherToken,
+    },
+  },
+});
+```
+
+:::caution[Be careful]
+Because of the nature of type-based injection, you can only do this for a single config item of a given type. If you have multiple config items of the same type, like two of the same type of token for two different plugin instances, you'll need to explicitly wire them up.
+:::
+
+
+
+### Multiple plugin instances
+
+Plugins support multiple instances allowing you to compose your configuration in a flexible way. For example, with the 1Password plugin you could create separate instances for your production and non-production vaults. Each instance can have its own settings, allowing you to manage per-environment or per-service secrets.
+
+When defining a plugin instance, you provide an `id` which will be used to identify the instance in various places, such as the CLI, UI, and when injecting it into other services.
+
+### Injecting plugin instances in monorepo services
+
+In a monorepo, you might want to use the same plugin instance across multiple services. If you will be using the same settings for each service, you can initialize a plugin instance once in a parent service as seen above, and then inject it in child services. Note that the injected plugin instance must use the same id we set during initialization.
+
+```typescript title='apps/some-service/.dmno/config.mts'
+import { SomePlugin } from '@dmno/some-plugin';
+
+// 💉 inject the already initialized plugin instead of re-initializing it
+const someInjectedPluginInstance = SomePlugin.injectInstance('some-plugin');
+```
+
+:::tip[Plugin instances are great for secret segmentation]
+
+To read more about secret segmentation, see the [Secrets guide](/docs/guides/secret-segmentation/).
+
+:::
+
+## Caching
+In order to avoid rate limits and keep dev server restarts extremely fast, we heavily cache data fetched from external sources. After updating secrets from any plugin that stores them externally, if the item has been cached, you'll need to clear the cache to see it take effect.
+
+- Use the [`dmno clear-cache` command](/docs/reference/cli/clear-cache/) to clear the cache once
+- The [`dmno resolve`](/docs/reference/cli/resolve/) and [`dmno run`](/docs/reference/cli/run/) commands have cache related flags:
+  - `--skip-cache` - skips caching logic altogether
+  - `--clear-cache` - clears the cache once before continuing as normal
+
+:::tip[Active config iteration]
+While you are actively working on the config itself, `dmno resolve -w --skip-cache` will combine watch mode with skipping cache logic.
+
+Once you are satisfied, clear the cache once more and you are good to go.
+:::
 
 
 :::note

--- a/packages/docs-site/src/content/docs/docs/plugins/overview.mdx
+++ b/packages/docs-site/src/content/docs/docs/plugins/overview.mdx
@@ -74,7 +74,7 @@ When defining a plugin instance, you provide an `id` which will be used to ident
 
 ### Injecting plugin instances in monorepo services
 
-In a monorepo, you might want to use the same plugin instance across multiple services. If you will be using the same settings for each service, you can initialize a plugin instance once in a parent service as seen above, and then inject it in child services. Note that the injected plugin instance must use the same id we set during initialization.
+In a monorepo, you might want to use the same plugin instance across multiple services. If you will be using the same settings for each service, you can initialize a plugin instance once in a parent service as seen above, and then inject it in child services. This alleviates the need to have the necessary config in each additional service. Note that the injected plugin instance must use the same id we set during initialization.
 
 ```typescript title='apps/some-service/.dmno/config.mts'
 import { SomePlugin } from '@dmno/some-plugin';

--- a/packages/plugins/infisical/.eslintrc.cjs
+++ b/packages/plugins/infisical/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ["@dmno/eslint-config/base"],
+  ignorePatterns: ["tsup.config.ts"],
+  rules: {  
+  },
+};

--- a/packages/plugins/infisical/README.md
+++ b/packages/plugins/infisical/README.md
@@ -16,16 +16,25 @@ Securely use your secrets and data from Infisical within DMNO Config Engine.
 
 You must initialize an instance of the plugin, giving it a unique ID and wiring up the access token to its location within your config schema.
 
-Then you can use the plugin instance which now has authentication, to fetch individual items by their UUID.
+Then you can use the plugin instance which now has authentication, to fetch individual items by their name.
 
 For example:
 
 ```typescript
 import { DmnoBaseTypes, defineDmnoService, configPath, NodeEnvType, switchBy, configPath } from 'dmno';
-import { BitwardenSecretsManagerDmnoPlugin, BitwardenSecretsManagerTypes } from '@dmno/bitwarden-plugin';
+import { InfisicalDmnoPlugin, InfisicalTypes } from '@dmno/infisical-plugin';
 
+// automatically injects the required config items by type
 const infisicalPlugin = new InfisicalDmnoPlugin('infisical', {
   environment: "dev",
+});
+
+// or you can explicitly wire it up by path, this is equivalent to the above
+const infisicalPlugin2 = new InfisicalDmnoPlugin('infisical', {
+  environment: "dev",
+  clientId: configPath('..', 'INFISICAL_CLIENT_ID'),
+  clientSecret: configPath('..', 'INFISICAL_CLIENT_SECRET'),
+  projectId: configPath('..', 'INFISICAL_PROJECT_ID'),
 });
 
 export default defineDmnoService({
@@ -40,18 +49,23 @@ export default defineDmnoService({
     INFISICAL_PROJECT_ID: {
       extends: InfisicalTypes.projectId,
     },
+    // USES IMPLICIT CONFIG ITEM NAME, must match the name in Infisical
     ITEM_FROM_INFISICAL: {
       value: infisicalPlugin.secret()
-    }
+    },
+    // USES EXPLICIT NAME from Infisical
+    ITEM_FROM_INFISICAL_BY_NAME: {
+      value: infisicalPlugin.secret('MY_SECRET_NAME')
+    },
     //...
 ```
 
-Since the access token is sensitive, you'll need to populate the value of `INFISICAL_TOKEN` using an override. For local development, you can store the machine access token in your `.dmno/.env.local` file, and in deployed environments you can set it as an environment variable.
+Since the access token is sensitive, you'll need to populate the value of `INFISICAL_CLIENT_SECRET` using an override. For local development, you can store the machine access token in your `.dmno/.env.local` file, and in deployed environments you can set it as an environment variable.
 
 ### Value Resolvers
 
 #### Fetch item by Name
-`infisicalPlugin.secretByName(name)`
+`infisicalPlugin.secret(nameOverride)`
 
 ### Data Types
 - `InfisicalTypes.clientId`

--- a/packages/plugins/infisical/README.md
+++ b/packages/plugins/infisical/README.md
@@ -1,0 +1,60 @@
+Check out the [docs](https://dmno.dev/docs/plugins/infisical/) for more information on how to use [DMNO](https://dmno.dev) with [Infisical](https://infisical.com/).
+
+*** THIS IS PREVIEW SOFTWARE AND SUBJECT TO RAPID CHANGE ***
+
+If you have any questions, please reach out to us on [Discord](https://chat.dmno.dev).
+
+----
+
+# @dmno/infisical-plugin [![npm](https://img.shields.io/npm/v/@dmno/infisical-plugin)](https://www.npmjs.com/package/@dmno/infisical-plugin)
+
+Securely use your secrets and data from Infisical within DMNO Config Engine.
+
+## Plugin
+
+### Initialization
+
+You must initialize an instance of the plugin, giving it a unique ID and wiring up the access token to its location within your config schema.
+
+Then you can use the plugin instance which now has authentication, to fetch individual items by their UUID.
+
+For example:
+
+```typescript
+import { DmnoBaseTypes, defineDmnoService, configPath, NodeEnvType, switchBy, configPath } from 'dmno';
+import { BitwardenSecretsManagerDmnoPlugin, BitwardenSecretsManagerTypes } from '@dmno/bitwarden-plugin';
+
+const infisicalPlugin = new InfisicalDmnoPlugin('infisical', {
+  environment: "dev",
+});
+
+export default defineDmnoService({
+  schema: {
+    //...
+    INFISICAL_CLIENT_ID: {
+      extends: InfisicalTypes.clientId,
+    },
+    INFISICAL_CLIENT_SECRET: {
+      extends: InfisicalTypes.clientSecret,
+    },
+    INFISICAL_PROJECT_ID: {
+      extends: InfisicalTypes.projectId,
+    },
+    ITEM_FROM_INFISICAL: {
+      value: infisicalPlugin.secret()
+    }
+    //...
+```
+
+Since the access token is sensitive, you'll need to populate the value of `INFISICAL_TOKEN` using an override. For local development, you can store the machine access token in your `.dmno/.env.local` file, and in deployed environments you can set it as an environment variable.
+
+### Value Resolvers
+
+#### Fetch item by Name
+`infisicalPlugin.secretByName(name)`
+
+### Data Types
+- `InfisicalTypes.clientId`
+- `InfisicalTypes.clientSecret`
+- `InfisicalTypes.environment`
+- `InfisicalTypes.projectId`

--- a/packages/plugins/infisical/package.json
+++ b/packages/plugins/infisical/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@dmno/infisical-plugin",
+  "version": "0.0.1",
+  "description": "dmno plugin to pull secrets from Infisical",
+  "author": "dmno-dev",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dmno-dev/dmno.git",
+    "directory": "packages/plugins/infisical"
+  },
+  "bugs": "https://github.com/dmno-dev/dmno/issues",
+  "homepage": "https://dmno.dev/docs/plugins/infisical",
+  "keywords": [
+    "dmno",
+    "infisical",
+    "config",
+    "env vars",
+    "environment variables",
+    "secrets",
+    "dmno-plugin"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "ts-src": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:ifnodist": "[ -d \"./dist\" ] && echo 'dist exists' || pnpm build",
+    "dev": "pnpm run build --watch",
+    "lint": "eslint src --ext .ts,.cjs,.mjs",
+    "lint:fix": "pnpm run lint --fix"
+  },
+  "devDependencies": {
+    "@dmno/eslint-config": "workspace:*",
+    "@dmno/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "dmno": "workspace:*",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@infisical/sdk": "^3.0.3"
+  },
+  "peerDependencies": {
+    "dmno": "^0"
+  }
+}

--- a/packages/plugins/infisical/package.json
+++ b/packages/plugins/infisical/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmno/infisical-plugin",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "dmno plugin to pull secrets from Infisical",
   "author": "dmno-dev",
   "license": "MIT",

--- a/packages/plugins/infisical/src/constants.ts
+++ b/packages/plugins/infisical/src/constants.ts
@@ -1,0 +1,1 @@
+export const INFISICAL_ICON = 'mdi:infinity';

--- a/packages/plugins/infisical/src/data-types.ts
+++ b/packages/plugins/infisical/src/data-types.ts
@@ -1,0 +1,66 @@
+import { DmnoBaseTypes, createDmnoDataType } from 'dmno';
+import { INFISICAL_ICON } from './constants';
+
+
+
+const InfisicalClientId = createDmnoDataType({
+  typeLabel: 'infisical/client-id',
+  // TODO: add a validation, but the rules and not published
+  extends: DmnoBaseTypes.string(),
+  typeDescription: 'Client ID for an Infisical client',
+  externalDocs: {
+    description: 'Infisical docs - client ID',
+    url: 'https://infisical.com/docs/documentation/platform/identities/universal-auth',
+  },
+  ui: {
+    icon: INFISICAL_ICON,
+  },
+  sensitive: true,
+});
+
+const InfisicalClientSecret = createDmnoDataType({
+  typeLabel: 'infisical/client-secret',
+  extends: DmnoBaseTypes.string(),
+  typeDescription: 'Client secret for an Infisical client',
+  externalDocs: {
+    description: 'Infisical docs - client secret',
+    url: 'https://infisical.com/docs/documentation/platform/identities/universal-auth',
+  },
+  ui: {
+    icon: INFISICAL_ICON,
+  },
+});
+
+const InfisicalEnvironment = createDmnoDataType({
+  typeLabel: 'infisical/environment',
+  extends: DmnoBaseTypes.string(),
+  typeDescription: 'Unique ID that identifies an environment in Infisical',
+  externalDocs: {
+    description: 'Infisical docs - environments',
+    url: 'https://infisical.com/docs/documentation/platform/environments',
+  },
+  ui: {
+    icon: INFISICAL_ICON,
+  },
+});
+
+const InfisicalProjectId = createDmnoDataType({
+  typeLabel: 'infisical/project-id',
+  extends: DmnoBaseTypes.uuid(),
+  typeDescription: 'Unique ID that identifies a project in Infisical',
+  externalDocs: {
+    description: 'Infisical docs - projects',
+    url: 'https://infisical.com/docs/documentation/platform/projects',
+  },
+  ui: {
+    icon: INFISICAL_ICON,
+  },
+});
+
+
+export const InfisicalTypes = {
+  clientId: InfisicalClientId,
+  clientSecret: InfisicalClientSecret,
+  environment: InfisicalEnvironment,
+  projectId: InfisicalProjectId,
+};

--- a/packages/plugins/infisical/src/index.ts
+++ b/packages/plugins/infisical/src/index.ts
@@ -1,0 +1,8 @@
+
+
+export * from './data-types';
+export * from './plugin';
+
+
+
+

--- a/packages/plugins/infisical/src/plugin.ts
+++ b/packages/plugins/infisical/src/plugin.ts
@@ -1,0 +1,127 @@
+import {
+  DmnoPlugin, inject, PluginInputValue, DmnoBaseTypes,
+  ResolutionError,
+} from 'dmno';
+import { InfisicalSDK } from '@infisical/sdk';
+
+import { INFISICAL_ICON } from './constants';
+
+import packageJson from '../package.json';
+import { InfisicalTypes } from './data-types';
+
+/**
+ * DMNO plugin to retrieve secrets from Infisical
+ *
+ * @see https://infisical.com/
+ */
+export class InfisicalDmnoPlugin extends DmnoPlugin {
+  icon = INFISICAL_ICON;
+
+  constructor(
+    instanceName: string,
+    inputValues: {
+      clientId?: PluginInputValue,
+      clientSecret?: PluginInputValue,
+      environment: string,
+      projectId?: PluginInputValue,
+      siteUrl?: string,
+    },
+  ) {
+    super(instanceName, {
+      packageJson,
+      inputSchema: {
+        clientId: {
+          extends: InfisicalTypes.clientId,
+          value: inputValues?.clientId || inject(),
+          required: true,
+        },
+        clientSecret: {
+          extends: InfisicalTypes.clientSecret,
+          value: inputValues?.clientSecret || inject(),
+          required: true,
+        },
+        environment: {
+          extends: InfisicalTypes.environment,
+          value: inputValues?.environment,
+          required: true,
+        },
+        projectId: {
+          extends: InfisicalTypes.projectId,
+          value: inputValues?.projectId || inject(),
+          required: true,
+        },
+        siteUrl: {
+          extends: DmnoBaseTypes.url(),
+          value: inputValues?.siteUrl || 'https://app.infisical.com',
+        },
+      },
+    });
+  }
+
+  private infisicalClient: InfisicalSDK | undefined;
+  private async getSdkClient() {
+    if (!this.infisicalClient) {
+      const clientId = this.inputValue('clientId') as string;
+      const clientSecret = this.inputValue('clientSecret') as string;
+      // const environment = this.inputValue('environment') as string;
+
+      this.infisicalClient = new InfisicalSDK({
+        siteUrl: this.inputValue('siteUrl') as string,
+      });
+
+      // TODO: add support for other auth methods
+      await this.infisicalClient.auth().universalAuth.login({
+        clientId,
+        clientSecret,
+      });
+    }
+    return this.infisicalClient!;
+  }
+
+  /**
+   * resolver to fetch a Infisical secret value by its name
+   *
+   * @see https://infisical.com/docs/documentation/platform/secrets/
+   */
+  secret(
+    /**
+     * Secret Name from Infisical dashboard
+     *
+     * @example MY_SECRET_NAME
+     */
+    nameOverride?: string,
+  ) {
+    return this.createResolver({
+      label: (ctx) => {
+        return `infisical secret > ${nameOverride || ctx.nodePath}`;
+      },
+      resolve: async (ctx) => {
+        const secretName = nameOverride || ctx.nodePath;
+
+        const isValid = DmnoBaseTypes.string().validate(secretName);
+        if (isValid !== true) throw isValid[0];
+        const environment = this.inputValue('environment') as string;
+        const projectId = this.inputValue('projectId') as string;
+
+        return await ctx.getOrSetCacheItem(`infisical:${projectId}:${environment}:${secretName}`, async () => {
+          const client = await this.getSdkClient();
+          try {
+            const secret = await client.secrets().getSecret({
+              environment,
+              projectId,
+              secretName,
+            });
+            return secret.secretValue;
+          } catch (err) {
+            throw new ResolutionError('Infisical secret not found', {
+              tip: [
+                `Check the secret name "${secretName}" and it's available in the "${environment}" environment`,
+                `See ${this.inputValue('siteUrl')}/project/${projectId}/secrets/overview`,
+              ],
+            });
+          }
+        });
+      },
+    });
+  }
+}

--- a/packages/plugins/infisical/tsconfig.json
+++ b/packages/plugins/infisical/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@dmno/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "module": "ESNext",
+    "outDir": "dist",
+    "lib": [
+      "ESNext"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "./.dmno/.typegen/extension-types.d.ts"
+  ]
+}

--- a/packages/plugins/infisical/tsup.config.ts
+++ b/packages/plugins/infisical/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [ // Entry point(s)
+    'src/index.ts', // main lib, users will import from here
+  ], 
+
+  dts: true, // Generate .d.ts files
+  // minify: true, // Minify output
+  sourcemap: true, // Generate sourcemaps
+  treeshake: true, // Remove unused code
+  
+  clean: true, // Clean output directory before building
+  outDir: "dist", // Output directory
+  
+  format: ['esm'], // Output format(s)
+  
+  splitting: true, // split output into chunks - MUST BE ON! or we get issues with multiple copies of classes and instanceof
+  keepNames: true, // stops build from prefixing our class names with `_` in some cases
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,6 +890,31 @@ importers:
         specifier: 'catalog:'
         version: 5.5.4
 
+  packages/plugins/infisical:
+    dependencies:
+      '@infisical/sdk':
+        specifier: ^3.0.3
+        version: 3.0.3
+    devDependencies:
+      '@dmno/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint-config
+      '@dmno/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.14.12
+      dmno:
+        specifier: workspace:*
+        version: link:../../core
+      tsup:
+        specifier: 'catalog:'
+        version: 8.2.4(jiti@1.21.0)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.5.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.5.4
+
   packages/signup-api:
     dependencies:
       '@dmno/ts-lib':
@@ -2712,6 +2737,9 @@ packages:
 
   '@import-maps/resolve@1.0.1':
     resolution: {integrity: sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA==}
+
+  '@infisical/sdk@3.0.3':
+    resolution: {integrity: sha512-pGQDH7zm6jI4qp2pZVPBj28ak/cX3CncHmhKeT/Nk9zm9PiNReYji7tbczeVUPsIJ+BrH0ZgP6q6LeojbXwsEA==}
 
   '@inquirer/checkbox@2.3.1':
     resolution: {integrity: sha512-w0B2PhvIh6SFA5uMh32FE+7xSuv1P2o/qjBb5jxgi1DB8VBFjSD3gHDsgiGDeSmfTaQDyR7/beDllIvKeA+YDw==}
@@ -4777,6 +4805,10 @@ packages:
   avvio@8.3.0:
     resolution: {integrity: sha512-VBVH0jubFr9LdFASy/vNtm5giTrnbVquWBhT0fyizuNK2rQ7e7ONU2plZQWUNqtE1EmxFEb+kbSkFRkstiaS9Q==}
 
+  aws-sdk@2.1311.0:
+    resolution: {integrity: sha512-X3cFNsfs3HUfz6LKiLqvDTO4EsqO5DnNssh9SOoxhwmoMyJ2et3dEmigO6TaA44BjVNdLW98+sXJVPTGvINY1Q==}
+    engines: {node: '>= 10.0.0'}
+
   axios@1.6.8:
     resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
 
@@ -4939,6 +4971,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -6266,6 +6301,10 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  events@1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -7106,6 +7145,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  ieee754@1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -7569,6 +7611,10 @@ packages:
   jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
+
+  jmespath@0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -9540,6 +9586,9 @@ packages:
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
 
+  punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -9555,6 +9604,11 @@ packages:
   qs@6.12.1:
     resolution: {integrity: sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==}
     engines: {node: '>=0.6'}
+
+  querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9979,6 +10033,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
 
   sax@1.3.0:
     resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
@@ -11203,6 +11260,9 @@ packages:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
 
+  url@0.10.3:
+    resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
+
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
 
@@ -11219,6 +11279,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -11863,6 +11927,13 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml2js@0.4.19:
+    resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
+
+  xmlbuilder@9.0.7:
+    resolution: {integrity: sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==}
+    engines: {node: '>=4.0'}
 
   xmlhttprequest-ssl@2.1.1:
     resolution: {integrity: sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==}
@@ -13620,6 +13691,15 @@ snapshots:
     optional: true
 
   '@import-maps/resolve@1.0.1': {}
+
+  '@infisical/sdk@3.0.3':
+    dependencies:
+      aws-sdk: 2.1311.0
+      axios: 1.7.7
+      typescript: 5.5.4
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - debug
 
   '@inquirer/checkbox@2.3.1':
     dependencies:
@@ -16596,6 +16676,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  aws-sdk@2.1311.0:
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      util: 0.12.5
+      uuid: 8.0.0
+      xml2js: 0.4.19
+
   axios@1.6.8:
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.4)
@@ -16811,6 +16904,12 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
 
   buffer@5.7.1:
     dependencies:
@@ -18422,6 +18521,8 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  events@1.1.1: {}
+
   events@3.3.0: {}
 
   execa@5.1.1:
@@ -19591,6 +19692,8 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
+  ieee754@1.1.13: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.1: {}
@@ -20001,6 +20104,8 @@ snapshots:
       pretty-format: 27.5.1
 
   jiti@1.21.0: {}
+
+  jmespath@0.16.0: {}
 
   joycon@3.1.1: {}
 
@@ -22876,6 +22981,8 @@ snapshots:
       inherits: 2.0.4
       pump: 2.0.1
 
+  punycode@1.3.2: {}
+
   punycode@2.3.1: {}
 
   pupa@3.1.0:
@@ -22889,6 +22996,8 @@ snapshots:
   qs@6.12.1:
     dependencies:
       side-channel: 1.0.6
+
+  querystring@0.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -23456,6 +23565,8 @@ snapshots:
   safe-stable-stringify@2.4.3: {}
 
   safer-buffer@2.1.2: {}
+
+  sax@1.2.1: {}
 
   sax@1.3.0: {}
 
@@ -24862,6 +24973,11 @@ snapshots:
 
   urix@0.1.0: {}
 
+  url@0.10.3:
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+
   urlpattern-polyfill@8.0.2: {}
 
   use@3.1.1: {}
@@ -24877,6 +24993,8 @@ snapshots:
       which-typed-array: 1.1.15
 
   utils-merge@1.0.1: {}
+
+  uuid@8.0.0: {}
 
   uuid@9.0.1: {}
 
@@ -25576,6 +25694,13 @@ snapshots:
   xdg-basedir@5.1.0: {}
 
   xml-name-validator@4.0.0: {}
+
+  xml2js@0.4.19:
+    dependencies:
+      sax: 1.3.0
+      xmlbuilder: 9.0.7
+
+  xmlbuilder@9.0.7: {}
 
   xmlhttprequest-ssl@2.1.1: {}
 


### PR DESCRIPTION
Adds support for reading secrets from [Infisical](https://infisical.com/). This first iteration supports universal auth and fetching individual secrets by name.

We may want to break out some of the new content that was added to Overview and give it its own nav items. 