### PR TITLE
Deprecate `switchByNodeEnv`

### DIFF
--- a/.changeset/silly-rivers-mate.md
+++ b/.changeset/silly-rivers-mate.md
@@ -1,0 +1,5 @@
+---
+"dmno": patch
+---
+
+deprecate switchByNodeEnv and clarify docs

--- a/example-repo/packages/api/.dmno/config-example.ts
+++ b/example-repo/packages/api/.dmno/config-example.ts
@@ -1,5 +1,5 @@
 import {
-  defineDmnoService, DmnoBaseTypes, configPath, dmnoFormula,switchByNodeEnv,
+  defineDmnoService, DmnoBaseTypes, configPath, dmnoFormula, switchBy,
   createDmnoDataType, ValidationError,
   EncryptedFileStorePlugin
 } from 'dmno';
@@ -132,7 +132,7 @@ export default defineDmnoService({
     // and a "value resolver" can always return another resolver, which lets you easily compose functionality 
     // NOTE - it's easy to author your own reusable resolvers to create whatever functionality you need
     SWITCHED_ENV_EXAMPLE: {
-      value: switchByNodeEnv({
+      value: switchBy('NODE_ENV', {
         _default: 'default-value',
         staging: (ctx) => `${ctx.get('NODE_ENV')}-value`,
         production: onePassSync.item("https://start.1password.com/open/i?a=I3GUA2KU6BD3FBHA47QNBIVEV4&v=ut2dftalm3ugmxc6klavms6tfq&i=bphvvrqjegfmd5yoz4buw2aequ&h=dmnoinc.1password.com"),

--- a/example-repo/packages/api/.dmno/config.mts
+++ b/example-repo/packages/api/.dmno/config.mts
@@ -1,4 +1,4 @@
-import { defineDmnoService, DmnoBaseTypes, switchByNodeEnv } from 'dmno';
+import { defineDmnoService, DmnoBaseTypes, switchBy } from 'dmno';
 import { OnePasswordDmnoPlugin } from '@dmno/1password-plugin';
 import { EncryptedVaultDmnoPlugin } from '@dmno/encrypted-vault-plugin';
 
@@ -50,7 +50,7 @@ export default defineDmnoService({
       sensitive: true,
     },
     SWITCHED_EXAMPLE: {
-      value: switchByNodeEnv({
+      value: switchBy('NODE_ENV', {
         _default: OnePassBackend.itemByReference("op://dev test/example/username"),
         staging: OnePassBackend.itemByReference("op://dev test/example/username"),
         production: OnePassBackend.itemByReference("op://dev test/example/username"),
@@ -79,7 +79,7 @@ export default defineDmnoService({
       description: 'public url of this service',
       extends: DmnoBaseTypes.string({}),
       expose: true,
-      value: switchByNodeEnv({
+      value: switchBy('NODE_ENV', {
         _default: () => `http://localhost:${DMNO_CONFIG.PORT}`,
         // staging: valueCreatedDuringDeployment(),
         production: 'https://api.dmnoexampleapp.com',

--- a/example-repo/packages/express-js/.dmno/config.mts
+++ b/example-repo/packages/express-js/.dmno/config.mts
@@ -1,4 +1,4 @@
-import { DmnoBaseTypes, defineDmnoService, switchByNodeEnv } from 'dmno';
+import { DmnoBaseTypes, defineDmnoService } from 'dmno';
 
 export default defineDmnoService({
   name: 'express-js',

--- a/example-repo/packages/nuxt-web/.dmno/config.mts
+++ b/example-repo/packages/nuxt-web/.dmno/config.mts
@@ -1,4 +1,4 @@
-import { DmnoBaseTypes, defineDmnoService, switchByNodeEnv } from 'dmno';
+import { DmnoBaseTypes, defineDmnoService } from 'dmno';
 
 export default defineDmnoService({
   name: 'nuxt',

--- a/packages/configraph/src/resolvers/switch.ts
+++ b/packages/configraph/src/resolvers/switch.ts
@@ -29,6 +29,11 @@ export function switchBy(switchByKey: string, branches: SwitchByResolverOptions)
   });
 }
 
+/**
+ * @deprecated better to use switchBy with a custom env flag
+ *
+ * @see https://dmno.dev/docs/guides/multi-env/
+ * */
 export const switchByNodeEnv = (branches: SwitchByResolverOptions) => switchBy('NODE_ENV', branches);
 export const switchByDmnoEnv = (branches: SwitchByResolverOptions) => switchBy('DMNO_ENV', branches);
 

--- a/packages/configraph/test/resolution.test.ts
+++ b/packages/configraph/test/resolution.test.ts
@@ -142,7 +142,7 @@ describe('graph resolution', () => {
       expect(e.configNodes.switchTest.schemaErrors).toHaveLength(1);
     });
 
-    test('we get a ResolutionError if no _deafult defined and no matching branch found', async () => {
+    test('we get a ResolutionError if no _default defined and no matching branch found', async () => {
       const g = new Configraph();
       const e = g.createEntity({
         configSchema: {

--- a/packages/core/src/cli/lib/init-helpers.ts
+++ b/packages/core/src/cli/lib/init-helpers.ts
@@ -6,8 +6,7 @@ import { parse as parseJSONC, modify as modifyJSONC, applyEdits as applyEditsJSO
 import buildEsmResolver from 'esm-resolve';
 import kleur from 'kleur';
 import { outdent } from 'outdent';
-import { input, confirm } from '@inquirer/prompts';
-import validatePackageName from 'validate-npm-package-name';
+import { confirm } from '@inquirer/prompts';
 import boxen from 'boxen';
 import { tryCatch, promiseDelay } from '@dmno/ts-lib';
 import { ScannedWorkspaceInfo } from '../../config-loader/find-services';

--- a/packages/docs-site/src/content/docs/docs/guides/env-files.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/env-files.mdx
@@ -16,7 +16,7 @@ When you run `dmno init`, DMNO will look for all `.env` files in your project an
 We try to infer as much about each config item as possible by:
 - Including related comments as a `description`
 - Infer the type (`extends`) based on the value for basic types like `boolean`, `number`, `email`, `url`
-- Set the `value` and not mark it as `sensitive` if the file was checked into source control. This includes using `value: switchByNodeEnv(...)` if values were found in multiple environment specific files
+- Set the `value` and not mark it as `sensitive` if the file was checked into source control. This includes using `value: switchBy('NODE_ENV', ...)` if values were found in multiple environment specific files
 - Set an `exampleValue` from a value from a `.env.sample`
 
 This automatic scaffolding of your config `schema` is meant to be a good starting point, but you should review it and make adjustments as necessary.

--- a/packages/docs-site/src/content/docs/docs/guides/multi-env.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/multi-env.mdx
@@ -3,79 +3,82 @@ title: Multi-environment configuration
 description: Use DMNO to simplify multi-environment configuration.
 ---
 
-## Overview
+DMNO supports multiple environments (e.g., dev/staging/prod) out of the box, allowing you to toggle config values based on the current environment. Many other config tools base their entire model around this concept, and you must redefine the entire set of config for each environment - resulting in copy pasted values, or awkward re-use mechanisms.
 
-DMNO supports multiple environments out of the box. This allows you to define different configuration item values in each environments. For example: development, staging, and production.
+In DMNO, your config is composed of a reactive graph of data and functions. One of those built-in functions is [`switchBy`](/docs/reference/helper-methods/#switchby), which allows you to introduce branching logic based on the current value of another item. Using `switchBy` with an environment flag is definitely the most common use-case, but there are many other useful applications as well.
 
-## Configuration
+## Values per environment using `switchBy`
 
-To define different configurations for different environments, you can use the [`switchByNodeEnv`](/docs/reference/helper-methods/#switchbynodeenv) helper method. This method takes an object where the keys are the environment names and the values are the configuration item for each environment. As is implied by the name, the configuration item for the current environment is selected based on the value of the `NODE_ENV` environment variable.
+The [`switchBy`](/docs/reference/helper-methods/#switchby) helper method selects a resolver branch based on the current value of another config item. In this case we toggle based on an environment flag, like `NODE_ENV`, or better yet a custom env flag that you have more control over.
+
+To use `switchBy`, we select another item by name to use as the switch condition, and provide a key-value object to define the different branches that might be selected. The keys are the possible expected values, with `_default` being a special reserved key that is selected if no match is found.
+
+Note that each branch can be a static value, a function, or a resolver - just like setting the value itself. This leads to some powerful composition capabilities.
 
 ```typescript
-import { switchByNodeEnv } from 'dmno';
+import { NodeEnvType, switchBy } from 'dmno';
 
 export default defineDmnoService({
-  pick: [
-    'NODE_ENV',
-  ],
   schema: {
-    OTHER_ITEM: {},
-    MY_CONFIG_ITEM: {
-      value: switchByNodeEnv({
-        _default: 'default value',
-        development: 'development value',
+    NODE_ENV: NodeEnvType,
+    TOGGLED_ITEM: {
+      value: switchBy('NODE_ENV', {
+        _default: 'default/development value',
         staging: 'staging value',
+        test: 'test value',
         production: () => {
           return DMNO_CONFIG.OTHER_ITEM ? 'production value' : 'production value 2';
         },
       }),
     },
-  },
-});
-```
-
-:::tip
-These don't need to be static values, they can be any valid configuration item, including references to secrets stored in a vault.
-:::
-
-You can define as many configuration items as you need using the `switchByNodeEnv` method.
-
-## Environment variables
-
-To set the environment for your application, you can use the `NODE_ENV` environment variable. This variable is commonly set to `development`, `staging`, or `production` depending on the environment.
-
-For example, to set the environment to `production` and do a production build, you could run:
-
-```bash
-NODE_ENV=production pnpm exec dmno run -- my-build-command-goes-here
-```
-
-This is especially useful when the value of `NODE_ENV` might not be what you would expect (we're looking at you [Netlify](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-environment)). For example, when running a build on a CI server, you might want to set the environment to `production` to ensure that the correct configuration values are used.
-
-## Other environments
-
-You may have a different env var that you want to use to switch between values. For example, you might want to use `APP_ENV` instead of `NODE_ENV`. You can do this by passing the name of the env var you want to use as the first argument to `switchBy`.
-
-```typescript
-import { switchBy } from 'dmno';
-
-export default defineDmnoService({
-  pick: [
-    'APP_ENV',
-  ],
-  schema: {
-    MY_CONFIG_ITEM: {
-      value: switchBy('APP_ENV', {
-        _default: 'default value',
-        development: 'development value',
-        staging: 'staging value',
-        production: 'production value',
-      }),
+    SOME_API_KEY: {
+      sensitive: true,
+      value: switchBy('NODE_ENV', {
+        _default: devSecretsVault.item(),
+        production: prodSecretsVault.item(),
+      },
     },
   },
 });
 ```
 
-:::note
-See the [switchBy](/docs/reference/helper-methods/#switchby) reference for more information.
-:::
+## Which environment flag should you use?
+
+While `NODE_ENV` is a common env flag that you are probably familiar with, we do not recommend using it! Historically, some 3rd party modules have altered their own behaviour based on this flag, so it's best to avoid it and leave `NODE_ENV=production`, especially in a staging environment where we want to run production-like code. It is common that other platforms inject their own env flag for the same reason.
+
+Even in those cases, we recommend creating your own more specific env flag, for example `APP_ENV`, that you have total control over. Here is an example of building our own env flag based on the env vars injected by Vercel. In this example, we'd like to differentiate between PR previews, branch previews, and a special staging branch.
+
+```ts title='.dmno/config.mts'
+import { defineDmnoService, switchBy, pickFromSchemaObject } from 'dmno';
+import { VercelEnvSchema } from '@dmno/vercel-platform';
+
+export default defineDmnoService({
+  schema: {
+    ...pickFromSchemaObject(VercelEnvSchema, 'VERCEL_ENV', 'VERCEL_GIT_COMMIT_REF'),
+    APP_ENV: {
+      value: () => {
+        if (DMNO_CONFIG.VERCEL_ENV === 'production') return 'production';
+        if (DMNO_CONFIG.VERCEL_ENV === 'preview') {
+          if (DMNO_CONFIG.VERCEL_GIT_PULL_REQUEST_ID) return 'pr-preview';
+          else if (DMNO_CONFIG.VERCEL_GIT_COMMIT_REF === 'staging') return 'staging';
+          else return 'branch-preview';
+        }
+        return 'development';
+      },
+    },
+    SOME_VAR: switchBy('APP_ENV', { /* ... */ }),
+  },
+});
+```
+
+In cases where the platform may not be injecting env vars, but you need to toggle the environment, you can pass it in as an env var from the command line. For example:
+
+```bash
+APP_ENV=production pnpm exec dmno run -- your-build-command
+```
+
+## Overrides from `process.env`
+
+Keep in mind that DMNO loads in process environment variables in as _overrides_, so there are many cases where your schema does not have a value defined for a certain environment flag, because you are expecting to receive it as an override. Sometimes this could be contextual information injected by the hosting platform, like `VERCEL_GIT_PULL_REQUEST_ID`, or it could be env vars that have been set via the platform's env var management UI. This will be especially true if you are migrating an existing project to DMNO.
+
+Over time, you may find it helpful to migrate more of your config into the schema and to a centralized secret store (like 1password). This reduces "secret sprawl", keeping things more secure and easier to reason about. In this case, you may still inject your "secret-zero" as an override, but everything else will be defined via the schema.

--- a/packages/docs-site/src/content/docs/docs/guides/multi-env.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/multi-env.mdx
@@ -5,11 +5,11 @@ description: Use DMNO to simplify multi-environment configuration.
 
 DMNO supports multiple environments (e.g., dev/staging/prod) out of the box, allowing you to toggle config values based on the current environment. Many other config tools base their entire model around this concept, and you must redefine the entire set of config for each environment - resulting in copy pasted values, or awkward re-use mechanisms.
 
-In DMNO, your config is composed of a reactive graph of data and functions. One of those built-in functions is [`switchBy`](/docs/reference/helper-methods/#switchby), which allows you to introduce branching logic based on the current value of another item. Using `switchBy` with an environment flag is definitely the most common use-case, but there are many other useful applications as well.
+In DMNO, your config is composed of a reactive graph of data and functions. One of those built-in functions is [`switchBy`](/docs/reference/helper-methods/#switchby), which allows you to introduce branching logic based on the current value of another item. Using `switchBy` with an environment flag is the most common use-case, but there are many other useful applications as well.
 
 ## Values per environment using `switchBy`
 
-The [`switchBy`](/docs/reference/helper-methods/#switchby) helper method selects a resolver branch based on the current value of another config item. In this case we toggle based on an environment flag, like `NODE_ENV`, or better yet a custom env flag that you have more control over.
+The [`switchBy`](/docs/reference/helper-methods/#switchby) helper method selects a resolver branch based on the current value of another config item. In this case, we toggle based on an environment flag, like `NODE_ENV`, or, better yet, a custom env flag that you have more control over.
 
 To use `switchBy`, we select another item by name to use as the switch condition, and provide a key-value object to define the different branches that might be selected. The keys are the possible expected values, with `_default` being a special reserved key that is selected if no match is found.
 
@@ -44,7 +44,7 @@ export default defineDmnoService({
 
 ## Which environment flag should you use?
 
-While `NODE_ENV` is a common env flag that you are probably familiar with, we do not recommend using it! Historically, some 3rd party modules have altered their own behaviour based on this flag, so it's best to avoid it and leave `NODE_ENV=production`, especially in a staging environment where we want to run production-like code. It is common that other platforms inject their own env flag for the same reason.
+While `NODE_ENV` is a common env flag that you are probably familiar with, **we do not recommend using it**. Historically, some 3rd party modules have altered their own behaviour based on this flag, so it's best to avoid it and leave `NODE_ENV=production`, especially in a staging environment where we want to run production-like code. It is common that other platforms inject their own env flag for the same reason.
 
 Even in those cases, we recommend creating your own more specific env flag, for example `APP_ENV`, that you have total control over. Here is an example of building our own env flag based on the env vars injected by Vercel. In this example, we'd like to differentiate between PR previews, branch previews, and a special staging branch.
 
@@ -81,4 +81,4 @@ APP_ENV=production pnpm exec dmno run -- your-build-command
 
 Keep in mind that DMNO loads in process environment variables in as _overrides_, so there are many cases where your schema does not have a value defined for a certain environment flag, because you are expecting to receive it as an override. Sometimes this could be contextual information injected by the hosting platform, like `VERCEL_GIT_PULL_REQUEST_ID`, or it could be env vars that have been set via the platform's env var management UI. This will be especially true if you are migrating an existing project to DMNO.
 
-Over time, you may find it helpful to migrate more of your config into the schema and to a centralized secret store (like 1password). This reduces "secret sprawl", keeping things more secure and easier to reason about. In this case, you may still inject your "secret-zero" as an override, but everything else will be defined via the schema.
+Over time, you may find it helpful to migrate more of your config into the schema and to a centralized secret store (like 1Password). This reduces secret sprawl, keeping things more secure and easier to reason about. In this case, you may still inject your _secret-zero_ as an override, but everything else will be defined via the schema.

--- a/packages/docs-site/src/content/docs/docs/reference/helper-methods.mdx
+++ b/packages/docs-site/src/content/docs/docs/reference/helper-methods.mdx
@@ -417,12 +417,6 @@ export default defineDmnoService({
 Having a `_default` branch is not required, but if there is no default branch and an unknown value is passed to the switch, you will get a `ResolutionError`. If this is not what you want, you must add `_default: undefined` or add branches for all expected switch values, even if they are set to resolve to `undefined`.
 :::
 
-### `switchByNodeEnv`
-
-`switchByNodeEnv({ branches })`
-
-This method is just a simple helper equivalent to `switchBy('NODE_ENV', ...)`.
-
-While switching based on an environment flag (e.g., dev/staging/prod) is definitely the most common use case for branching logic in your config, we do not recommend using `NODE_ENV` as that flag. Package managers alter their behavior based on `NODE_ENV`, and while it is not the best practice, so do some 3rd party modules.
-
-Instead we recommend defining your own env flag, for example `APP_ENV`, `ACME_ENV`, etc.  This allows you to have more control and be more specific. For example, you may want to have `development`, `test`, `test-ci`, `preview`, `staging`, `production`. Being more specific and toggling the rest of your config using that flag fits very naturally with using DMNO.
+:::note[Switching based on environment]
+While switching based on an environment flag (e.g., dev/staging/prod) is definitely the most common use case for branching logic in your config, we do not recommend using `NODE_ENV` as that flag for most projects. See our [Multiple Environments guide](/docs/guides/multi-env/) for more details.
+:::

--- a/packages/docs-site/src/content/docs/docs/reference/helper-methods.mdx
+++ b/packages/docs-site/src/content/docs/docs/reference/helper-methods.mdx
@@ -418,5 +418,5 @@ Having a `_default` branch is not required, but if there is no default branch an
 :::
 
 :::note[Switching based on environment]
-While switching based on an environment flag (e.g., dev/staging/prod) is definitely the most common use case for branching logic in your config, we do not recommend using `NODE_ENV` as that flag for most projects. See our [Multiple Environments guide](/docs/guides/multi-env/) for more details.
+While switching based on an environment flag (e.g., dev/staging/prod) is the most common use case for branching logic in your config, we do not recommend using `NODE_ENV` as that flag for most projects. See our [Multiple Environments guide](/docs/guides/multi-env/) for more details.
 :::


### PR DESCRIPTION
In the process of cleaning up the docs and explaining why you shouldn't really be switching config based on `NODE_ENV`, we decided we should probably deprecate `switchByNodeEnv` in order to help drive home the point.

In the process I also put some more work into the docs to explain why, how to use a different flag, and generally about switching values based on environment.

The interesting part of this PR is an overhaul of this page - https://deploy-preview-155--dmno.netlify.app/docs/guides/multi-env/