### PR TITLE
allow .env style output from resolve and add associated docs

### DIFF
--- a/.changeset/hungry-terms-cross.md
+++ b/.changeset/hungry-terms-cross.md
@@ -1,0 +1,5 @@
+---
+"dmno": patch
+---
+
+adds env as an output format option for dmno resolve

--- a/packages/core/src/cli/commands/resolve.command.ts
+++ b/packages/core/src/cli/commands/resolve.command.ts
@@ -50,8 +50,6 @@ program.action(async (opts: {
   const ctx = getCliRunCtx();
 
   const isSilent = !!opts.silent || isSubshell();
-  // console.log('isSilent', isSilent);
-  // console.log('subshell', isSubshell());
 
   if (opts.format) ctx.expectingOutput = true;
 

--- a/packages/core/src/cli/commands/resolve.command.ts
+++ b/packages/core/src/cli/commands/resolve.command.ts
@@ -14,6 +14,7 @@ import { addCacheFlags } from '../lib/cache-helpers';
 import { addWatchMode } from '../lib/watch-mode-helpers';
 import { CliExitError } from '../lib/cli-error';
 import { checkForConfigErrors, checkForSchemaErrors } from '../lib/check-errors-helpers';
+import { stringifyObjectAsEnvFile } from '../lib/env-file-helpers';
 
 const program = new DmnoCommand('resolve')
   .summary('Loads config schema and resolves config values')
@@ -23,7 +24,9 @@ const program = new DmnoCommand('resolve')
   .option('--show-all', 'shows all items, even when config is failing')
   .example('dmno resolve', 'Loads the resolved config for the root service')
   .example('dmno resolve --service service1', 'Loads the resolved config for service1')
-  .example('dmno resolve --service service1 --format json', 'Loads the resolved config for service1 in JSON format');
+  .example('dmno resolve --service service1 --format json', 'Loads the resolved config for service1 in JSON format')
+  .example('dmno resolve --service service1 --format env', 'Loads the resolved config for service1 and outputs it in .env file format')
+  .example('dmno resolve --service service1 --format env >> .env.local', 'Loads the resolved config for service1 and outputs it in .env file format and writes to .env.local');
 
 addWatchMode(program); // must be first
 addCacheFlags(program);
@@ -55,20 +58,23 @@ program.action(async (opts: {
   await workspace.resolveConfig();
   checkForConfigErrors(service, { showAll: opts?.showAll });
 
-  // console.log(service.config);
-  if (opts.format === 'json') {
+  const getExposedConfigValues = () => {
     let exposedConfig = service.config;
     if (opts.public) {
       exposedConfig = _.pickBy(exposedConfig, (c) => !c.type.getMetadata('sensitive'));
     }
-    const valuesOnly = _.mapValues(exposedConfig, (val) => val.resolvedValue);
+    return _.mapValues(exposedConfig, (val) => val.resolvedValue);
+  };
 
-    console.log(JSON.stringify(valuesOnly));
+  // console.log(service.config);
+  if (opts.format === 'json') {
+    console.log(JSON.stringify(getExposedConfigValues()));
   } else if (opts.format === 'json-full') {
-    // TODO: this includes sensitive info when using --public option
     console.dir(service.toJSON(), { depth: null });
   } else if (opts.format === 'json-injected') {
     console.log(JSON.stringify(service.configraphEntity.getInjectedEnvJSON()));
+  } else if (opts.format === 'env') {
+    console.log(stringifyObjectAsEnvFile(getExposedConfigValues()));
   } else {
     _.each(service.config, (item) => {
       console.log(getItemSummary(item.toJSON()));

--- a/packages/core/src/cli/commands/resolve.command.ts
+++ b/packages/core/src/cli/commands/resolve.command.ts
@@ -15,6 +15,7 @@ import { addWatchMode } from '../lib/watch-mode-helpers';
 import { CliExitError } from '../lib/cli-error';
 import { checkForConfigErrors, checkForSchemaErrors } from '../lib/check-errors-helpers';
 import { stringifyObjectAsEnvFile } from '../lib/env-file-helpers';
+import { isSubshell } from '../lib/shell-helpers';
 
 const program = new DmnoCommand('resolve')
   .summary('Loads config schema and resolves config values')
@@ -22,6 +23,7 @@ const program = new DmnoCommand('resolve')
   .option('-f,--format <format>', 'format to output resolved config (ex. json)')
   .option('--public', 'only loads public (non-sensitive) values')
   .option('--show-all', 'shows all items, even when config is failing')
+  .option('--silent', 'automatically select defaults and do not prompt for any input')
   .example('dmno resolve', 'Loads the resolved config for the root service')
   .example('dmno resolve --service service1', 'Loads the resolved config for service1')
   .example('dmno resolve --service service1 --format json', 'Loads the resolved config for service1 in JSON format')
@@ -43,12 +45,18 @@ program.action(async (opts: {
   format?: string,
   public?: boolean,
   showAll?: boolean,
+  silent?: boolean,
 }, thisCommand) => {
   const ctx = getCliRunCtx();
 
+  const isSilent = !!opts.silent || isSubshell();
+  // console.log('isSilent', isSilent);
+  // console.log('subshell', isSubshell());
+
   if (opts.format) ctx.expectingOutput = true;
 
-  if (!ctx.selectedService) return; // error message already handled
+  if (!ctx.selectedService && !isSilent) return; // error message already handled
+
 
   ctx.log(`\nResolving config for service ${kleur.magenta(ctx.selectedService.serviceName)}\n`);
 

--- a/packages/core/src/cli/commands/resolve.command.ts
+++ b/packages/core/src/cli/commands/resolve.command.ts
@@ -23,7 +23,6 @@ const program = new DmnoCommand('resolve')
   .option('-f,--format <format>', 'format to output resolved config (ex. json)')
   .option('--public', 'only loads public (non-sensitive) values')
   .option('--show-all', 'shows all items, even when config is failing')
-  .option('--silent', 'automatically select defaults and do not prompt for any input')
   .example('dmno resolve', 'Loads the resolved config for the root service')
   .example('dmno resolve --service service1', 'Loads the resolved config for service1')
   .example('dmno resolve --service service1 --format json', 'Loads the resolved config for service1 in JSON format')
@@ -32,7 +31,7 @@ const program = new DmnoCommand('resolve')
 
 addWatchMode(program); // must be first
 addCacheFlags(program);
-addServiceSelection(program);
+addServiceSelection(program, { disablePrompt: isSubshell() });
 
 
 program.action(async (opts: {
@@ -45,15 +44,12 @@ program.action(async (opts: {
   format?: string,
   public?: boolean,
   showAll?: boolean,
-  silent?: boolean,
 }, thisCommand) => {
   const ctx = getCliRunCtx();
 
-  const isSilent = !!opts.silent || isSubshell();
-
   if (opts.format) ctx.expectingOutput = true;
 
-  if (!ctx.selectedService && !isSilent) return; // error message already handled
+  if (!ctx.selectedService) return; // error message already handled
 
 
   ctx.log(`\nResolving config for service ${kleur.magenta(ctx.selectedService.serviceName)}\n`);

--- a/packages/core/src/cli/lib/env-file-helpers.test.ts
+++ b/packages/core/src/cli/lib/env-file-helpers.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, describe } from 'vitest';
+import { stringifyObjectAsEnvFile } from './env-file-helpers';
+
+describe('stringifyObjectAsEnvFile', () => {
+  test('basic', () => {
+    const result = stringifyObjectAsEnvFile({ foo: 'bar', baz: 'qux' });
+    expect(result).toEqual('foo="bar"\nbaz="qux"');
+  });
+  test('escapes backslashes', () => {
+    const result = stringifyObjectAsEnvFile({ foo: 'bar\\baz' });
+    expect(result).toEqual('foo="bar\\\\baz"');
+  });
+  test('escapes newlines', () => {
+    const result = stringifyObjectAsEnvFile({ foo: 'bar\nbaz' });
+    expect(result).toEqual('foo="bar\\nbaz"');
+  });
+  test('escapes double quotes', () => {
+    const result = stringifyObjectAsEnvFile({ foo: 'bar"baz' });
+    expect(result).toEqual('foo="bar\\"baz"');
+  });
+});

--- a/packages/core/src/cli/lib/env-file-helpers.ts
+++ b/packages/core/src/cli/lib/env-file-helpers.ts
@@ -1,0 +1,11 @@
+export function stringifyObjectAsEnvFile(obj: Record<string, string>) {
+  return Object.entries(obj).map(([key, value]) => {
+    // Handle newlines and quotes by wrapping in double quotes and escaping
+    const formattedValue = String(value)
+      .replace(/\\/g, '\\\\') // escape backslashes first
+      .replace(/\n/g, '\\n') // escape newlines
+      .replace(/"/g, '\\"'); // escape double quotes
+
+    return `${key}="${formattedValue}"`;
+  }).join('\n');
+}

--- a/packages/core/src/cli/lib/shell-helpers.test.ts
+++ b/packages/core/src/cli/lib/shell-helpers.test.ts
@@ -1,0 +1,15 @@
+import { execSync, spawn } from 'child_process';
+import { expect, test, describe } from 'vitest';
+import { isSubshell } from './shell-helpers';
+
+describe('isSubshell', () => {
+  test('basic', () => {
+    expect(isSubshell()).toBe(false);
+  });
+  test('subshell', () => {
+    const child = spawn('bash', ['-c', 'echo $PPID $(echo $PPID)']);
+    child.stdout.on('data', () => {
+      expect(isSubshell()).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/cli/lib/shell-helpers.ts
+++ b/packages/core/src/cli/lib/shell-helpers.ts
@@ -1,1 +1,1 @@
-export const isSubshell = () => (process.env.BASH_SUBSHELL && process.env.BASH_SUBSHELL !== '0') || false;
+export const isSubshell = () => !process.stdin.isTTY;

--- a/packages/core/src/cli/lib/shell-helpers.ts
+++ b/packages/core/src/cli/lib/shell-helpers.ts
@@ -1,0 +1,1 @@
+export const isSubshell = () => (process.env.BASH_SUBSHELL && process.env.BASH_SUBSHELL !== '0') || false;

--- a/packages/docs-site/src/content/docs/docs/guides/env-files.mdx
+++ b/packages/docs-site/src/content/docs/docs/guides/env-files.mdx
@@ -50,4 +50,24 @@ If you're using [plugins](/docs/plugins/overview/) to handle your sensitive conf
 When running `dmno init`, we prompt you to move any gitignored `.env` files we find into your `.dmno` folder. This means that other tools that may be looking for will not find them - which is on purpose. Instead, you should pass resolved config to those external tools via `dmno run`, whether `.env` files are being used or not.
 :::
 
+## Resolving config and outputting to .env format
+
+You can use the [`dmno resolve` command](/docs/reference/cli/resolve/) to load the resolved config for a service and output it in `.env` file format. This is useful for quickly exporting all your config values to a file for use in other systems, especially in some serverless environments where you may need to set a lot of environment variables at once and you don't have as much control over the running process as you do locally.
+
+Consider the following example where we want to load an `.env` file for use in Supabase Edge Functions.
+
+You can run the following command to load the resolved config for your `api` service and output it to a file.
+
+```bash
+pnpm exec dmno resolve --service api --format env >> .env.production
+supabase secrets set --env-file .env.production
+```
+
+If you want to do this with a single command, you can combine them like this:
+
+```bash
+supabase secrets set --env-file <(pnpm exec dmno resolve --service api --format env)
+```
+This has the added benefit of writing no file, so you don't need to worry about deleting it later or accidentally checking it into source control.
+
 {/* Will need to add a note about nested config and special `__` separator (ie PARENT__CHILD) */}


### PR DESCRIPTION
Adds the `env` format option for the `--format` flag in `dmno resolve`
Adds the -np or --no-prompt flag to bypass the service selection for `dmno resolve`
Automatically detects if you're in a non-interactive shell (like a subshell) and also moves into non-interactive mode

For example: 

`pnpm exec dmno resolve --service api --format env >> .env.production`

adds docs to: 
- `dmno resolve` page
- .env Files guide page

fixes #160 