### PR TITLE
nextjs config fixes

### DIFF
--- a/.changeset/gorgeous-chefs-admire.md
+++ b/.changeset/gorgeous-chefs-admire.md
@@ -1,0 +1,5 @@
+---
+"@dmno/nextjs-integration": patch
+---
+
+support next config file functions, ts/cjs

--- a/packages/integrations/nextjs/package.json
+++ b/packages/integrations/nextjs/package.json
@@ -25,9 +25,10 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "ts-src": "./src/index.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./meta": {
       "default": "./dmno.meta.json"
@@ -57,5 +58,8 @@
   "peerDependencies": {
     "dmno": "^0",
     "next": "^14"
+  },
+  "dependencies": {
+    "import-meta-resolve": "^4.1.0"
   }
 }

--- a/packages/integrations/nextjs/src/index.ts
+++ b/packages/integrations/nextjs/src/index.ts
@@ -1,14 +1,9 @@
 /* eslint-disable prefer-rest-params */
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
-
 import { injectDmnoGlobals } from 'dmno/injector-standalone';
-
+import { resolve } from 'import-meta-resolve';
 import type { NextConfig } from 'next';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
 
 const {
   staticReplacements, dynamicKeys, injectedDmnoEnv, serviceSettings,
@@ -17,6 +12,12 @@ const {
 type DmnoPluginOptions = {
   injectResolvedConfigAtBuildTime: boolean,
 };
+
+export type NextConfigFunction = (
+  phase: string,
+  defaults: { defaultConfig: NextConfig },
+) => NextConfig | PromiseLike<NextConfig>;
+
 
 function patchFsWriteFileToPreventClientLeaks() {
   const origPromisesWriteFileFn = fs.promises.writeFile;
@@ -42,7 +43,7 @@ function patchFsWriteFileToPreventClientLeaks() {
 const WEBPACK_PLUGIN_NAME = 'DmnoNextWebpackPlugin';
 
 function getCjsModuleSource(moduleName: string) {
-  const modulePath = fileURLToPath(import.meta.resolve(moduleName)).replace('.js', '.cjs');
+  const modulePath = fileURLToPath(resolve(moduleName, import.meta.url)).replace('.js', '.cjs');
   const moduleSrc = fs.readFileSync(modulePath, 'utf8');
   return moduleSrc;
 }
@@ -59,177 +60,187 @@ export function dmnoNextConfigPlugin(dmnoOptions?: DmnoPluginOptions) {
   // detect if we need to build the resolved config into the output
   // which is needed when running on external platforms where we dont have ability to use `dmno run`
   const injectResolvedConfigAtBuildTime = (
-    process.env.__VERCEL_BUILD_RUNNING // build running via `vercel` cli
+    (process.env.__VERCEL_BUILD_RUNNING || process.env.VERCEL) // build running via `vercel` cli or on vercel
     || process.env.NETLIFY // build running remotely on netlify
     || (process.env.NETLIFY_LOCAL && !process.env.NETLIFY_DEV) // build running locally via `netlify` cli
     || dmnoOptions?.injectResolvedConfigAtBuildTime // explicit opt-in
   );
 
   // nextjs doesnt have a proper plugin system, so we write a function which takes in a config object and returns an augmented one
-  return (nextConfig: NextConfig): NextConfig => {
-    if (nextConfig.output === 'export' && dynamicKeys.length) {
-      console.error([
-        'Dynamic config is not supported in static builds (next.config output="export")',
-        'Set `settings.dynamicConfig` to "only_static" in your .dmno/config.mts file',
-        `Dynamic config items: ${dynamicKeys.join(', ')}`,
-      ].join('\n'));
+  return (nextConfig: any | NextConfig | NextConfigFunction): NextConfigFunction => {
+    return async (phase: string, defaults: { defaultConfig: NextConfig }) => {
+      let resolvedNextConfig: NextConfig;
+      if (typeof nextConfig === 'function') {
+        const nextConfigFnResult = nextConfig(phase, defaults);
+        resolvedNextConfig = await nextConfigFnResult;
+      } else {
+        resolvedNextConfig = nextConfig;
+      }
 
-      throw new Error('Dynamic config not compatible with static builds');
-    }
+      if (resolvedNextConfig.output === 'export' && dynamicKeys.length) {
+        console.error([
+          'Dynamic config is not supported in static builds (next.config output="export")',
+          'Set `settings.dynamicConfig` to "only_static" in your .dmno/config.mts file',
+          `Dynamic config items: ${dynamicKeys.join(', ')}`,
+        ].join('\n'));
 
-    return {
-      ...nextConfig,
-      webpack(webpackConfig, options) {
-        const { isServer } = options;
+        throw new Error('Dynamic config not compatible with static builds');
+      }
 
-        // webpack itself  is passed in so we dont have to import it...
-        const webpack = options.webpack;
+      return {
+        ...resolvedNextConfig,
+        webpack(webpackConfig, options) {
+          const { isServer } = options;
 
-        // apply existing user customizations if there are any
-        if (nextConfig.webpack) {
-          webpackConfig = nextConfig.webpack(webpackConfig, options);
-        }
+          // webpack itself  is passed in so we dont have to import it...
+          const webpack = options.webpack;
 
-        // modify entry points to inject our dmno env shim
-        // currently this strategy only works for injecting into the client
-        const originalEntry = webpackConfig.entry;
-        webpackConfig.entry = async () => {
-          const entries = await originalEntry();
+          // apply existing user customizations if there are any
+          if (resolvedNextConfig.webpack) {
+            webpackConfig = resolvedNextConfig.webpack(webpackConfig, options);
+          }
 
-          function injectEntry(entryKey: string, injectedPath: string) {
-            if (
-              entries[entryKey]
-            ) {
-              if (!Array.isArray(entries[entryKey])) {
-                entries[entryKey] = [entries[entryKey]];
-              }
-              if (!entries[entryKey].includes(injectedPath)) {
-                entries[entryKey].unshift(injectedPath);
+          // modify entry points to inject our dmno env shim
+          // currently this strategy only works for injecting into the client
+          const originalEntry = webpackConfig.entry;
+          webpackConfig.entry = async () => {
+            const entries = await originalEntry();
+
+            function injectEntry(entryKey: string, injectedPath: string) {
+              if (
+                entries[entryKey]
+              ) {
+                if (!Array.isArray(entries[entryKey])) {
+                  entries[entryKey] = [entries[entryKey]];
+                }
+                if (!entries[entryKey].includes(injectedPath)) {
+                  entries[entryKey].unshift(injectedPath);
+                }
               }
             }
-          }
 
-          // injecting into server entries does not seem to work in all situations :(
-          // if (isServer) console.log('server entries!', entries);
+            // injecting into server entries does not seem to work in all situations :(
+            // if (isServer) console.log('server entries!', entries);
 
-          // injects our DMNO_CONFIG shims into the client
-          // which gives us nicer errors and also support for dynamic public config
-          if (!isServer) {
-            const injectDmnoClientFilePath = `${__dirname}/inject-dmno-client.js`;
-            injectEntry('main-app', injectDmnoClientFilePath);
-            injectEntry('main', injectDmnoClientFilePath);
-            injectEntry('amp', injectDmnoClientFilePath);
-          }
+            // injects our DMNO_CONFIG shims into the client
+            // which gives us nicer errors and also support for dynamic public config
+            if (!isServer) {
+              const injectDmnoClientFilePath = `${__dirname}/inject-dmno-client.js`;
+              injectEntry('main-app', injectDmnoClientFilePath);
+              injectEntry('main', injectDmnoClientFilePath);
+              injectEntry('amp', injectDmnoClientFilePath);
+            }
 
-          return entries;
-        };
-
-        // Set up replacements / rewrites (using webpack DefinePlugin)
-        webpackConfig.plugins.push(new webpack.DefinePlugin({
-          ...staticReplacements.dmnoPublicConfig,
-          ...isServer && staticReplacements.dmnoConfig,
-        }));
-
-        // updates the webpack source to inject dmno global logic and call it
-        // we run this on the runtimes for serverless and edge
-        function updateServerRuntimeToInjectDmno(edgeRuntime = false) {
-          return function (origSource: any) {
-            const origSourceStr = origSource.source();
-
-            // we will inline the injector code, but need a different version if we are running in the edge runtime
-            const injectorSrc = getCjsModuleSource(`dmno/injector-standalone${edgeRuntime ? '/edge' : ''}`);
-
-            const updatedSourceStr = [
-              // we use `headers()` to force next into dynamic rendering mode, but on the edge runtime it's always dynamic
-              // (see below for where headers is used)
-              !edgeRuntime ? 'const { headers } = require("next/headers");' : '',
-
-              // code built for edge runtime does not have `module.exports` or `exports` but we are inlining some already built common-js code
-              // so we just create them. It's not needed since it is inlined and we call the function right away
-              edgeRuntime ? 'const module = { exports: {} }; const exports = {}' : '',
-
-              // inline the dmno injector code and then call it
-              injectorSrc,
-              'injectDmnoGlobals({',
-              injectResolvedConfigAtBuildTime ? `injectedConfig: ${JSON.stringify(injectedDmnoEnv)},` : '',
-
-              // attempts to force the route into dynamic rendering mode so it wont put our our dynamic value into a pre-rendered page
-              // however we have to wrap in try/catch because you can only call headers() within certain parts of the page... so it's not 100% foolproof
-              !edgeRuntime ? `
-                onItemAccess: async (item) => {
-                  if (item.dynamic) {
-                    try { headers(); }
-                    catch (err) {}
-                  }
-                },` : '',
-              '});',
-
-              origSourceStr,
-            ].join('\n');
-
-            return new webpack.sources.RawSource(updatedSourceStr);
+            return entries;
           };
-        }
+
+          // Set up replacements / rewrites (using webpack DefinePlugin)
+          webpackConfig.plugins.push(new webpack.DefinePlugin({
+            ...staticReplacements.dmnoPublicConfig,
+            ...isServer && staticReplacements.dmnoConfig,
+          }));
+
+          // updates the webpack source to inject dmno global logic and call it
+          // we run this on the runtimes for serverless and edge
+          function updateServerRuntimeToInjectDmno(edgeRuntime = false) {
+            return function (origSource: any) {
+              const origSourceStr = origSource.source();
+
+              // we will inline the injector code, but need a different version if we are running in the edge runtime
+              const injectorSrc = getCjsModuleSource(`dmno/injector-standalone${edgeRuntime ? '/edge' : ''}`);
+
+              const updatedSourceStr = [
+                // we use `headers()` to force next into dynamic rendering mode, but on the edge runtime it's always dynamic
+                // (see below for where headers is used)
+                !edgeRuntime ? 'const { headers } = require("next/headers");' : '',
+
+                // code built for edge runtime does not have `module.exports` or `exports` but we are inlining some already built common-js code
+                // so we just create them. It's not needed since it is inlined and we call the function right away
+                edgeRuntime ? 'const module = { exports: {} }; const exports = {}' : '',
+
+                // inline the dmno injector code and then call it
+                injectorSrc,
+                'injectDmnoGlobals({',
+                injectResolvedConfigAtBuildTime ? `injectedConfig: ${JSON.stringify(injectedDmnoEnv)},` : '',
+
+                // attempts to force the route into dynamic rendering mode so it wont put our our dynamic value into a pre-rendered page
+                // however we have to wrap in try/catch because you can only call headers() within certain parts of the page... so it's not 100% foolproof
+                !edgeRuntime ? `
+                  onItemAccess: async (item) => {
+                    if (item.dynamic) {
+                      try { headers(); }
+                      catch (err) {}
+                    }
+                  },` : '',
+                '});',
+
+                origSourceStr,
+              ].join('\n');
+
+              return new webpack.sources.RawSource(updatedSourceStr);
+            };
+          }
 
 
-        // we need to inject the dmno globals injector and call it
-        // and in vercel/netlify etc where we can't run via `dmno run` we need to inject the resolved config into the build
-        // not sure if this is the best way, but injecting into the `webpack-runtime.js` file seems to run everywhere
-        webpackConfig.plugins.push({
-          apply(compiler: any) {
-            compiler.hooks.thisCompilation.tap(WEBPACK_PLUGIN_NAME, (compilation: any) => {
-              compilation.hooks.processAssets.tap(
-                {
-                  name: WEBPACK_PLUGIN_NAME,
-                  stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
-                },
-                () => {
-                  // not sure why, but these paths are different in build vs dev
-                  if (compilation.getAsset('webpack-runtime.js')) {
-                    compilation.updateAsset('webpack-runtime.js', updateServerRuntimeToInjectDmno());
-                  }
-                  if (compilation.getAsset('../webpack-runtime.js')) {
-                    compilation.updateAsset('../webpack-runtime.js', updateServerRuntimeToInjectDmno());
-                  }
-                  if (compilation.getAsset('webpack-api-runtime.js')) {
-                    compilation.updateAsset('webpack-api-runtime.js', updateServerRuntimeToInjectDmno());
-                  }
-                  if (compilation.getAsset('../webpack-api-runtime.js')) {
-                    compilation.updateAsset('../webpack-api-runtime.js', updateServerRuntimeToInjectDmno());
-                  }
+          // we need to inject the dmno globals injector and call it
+          // and in vercel/netlify etc where we can't run via `dmno run` we need to inject the resolved config into the build
+          // not sure if this is the best way, but injecting into the `webpack-runtime.js` file seems to run everywhere
+          webpackConfig.plugins.push({
+            apply(compiler: any) {
+              compiler.hooks.thisCompilation.tap(WEBPACK_PLUGIN_NAME, (compilation: any) => {
+                compilation.hooks.processAssets.tap(
+                  {
+                    name: WEBPACK_PLUGIN_NAME,
+                    stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+                  },
+                  () => {
+                    // not sure why, but these paths are different in build vs dev
+                    if (compilation.getAsset('webpack-runtime.js')) {
+                      compilation.updateAsset('webpack-runtime.js', updateServerRuntimeToInjectDmno());
+                    }
+                    if (compilation.getAsset('../webpack-runtime.js')) {
+                      compilation.updateAsset('../webpack-runtime.js', updateServerRuntimeToInjectDmno());
+                    }
+                    if (compilation.getAsset('webpack-api-runtime.js')) {
+                      compilation.updateAsset('webpack-api-runtime.js', updateServerRuntimeToInjectDmno());
+                    }
+                    if (compilation.getAsset('../webpack-api-runtime.js')) {
+                      compilation.updateAsset('../webpack-api-runtime.js', updateServerRuntimeToInjectDmno());
+                    }
 
-                  if (compilation.getAsset('edge-runtime-webpack.js')) {
-                    compilation.updateAsset('edge-runtime-webpack.js', updateServerRuntimeToInjectDmno(true));
-                  }
-                },
-              );
-            });
+                    if (compilation.getAsset('edge-runtime-webpack.js')) {
+                      compilation.updateAsset('edge-runtime-webpack.js', updateServerRuntimeToInjectDmno(true));
+                    }
+                  },
+                );
+              });
 
-            // add webpack hook to handle leaks in 'use client' pages
-            // since this ends up in a built js file instead of a server response
-            if (serviceSettings?.preventClientLeaks) {
-              // scan built js files
-              compiler.hooks.assetEmitted.tap(
-                WEBPACK_PLUGIN_NAME,
-                (file: any, assetDetails: any) => {
-                  const { content, targetPath } = assetDetails;
+              // add webpack hook to handle leaks in 'use client' pages
+              // since this ends up in a built js file instead of a server response
+              if (serviceSettings?.preventClientLeaks) {
+                // scan built js files
+                compiler.hooks.assetEmitted.tap(
+                  WEBPACK_PLUGIN_NAME,
+                  (file: any, assetDetails: any) => {
+                    const { content, targetPath } = assetDetails;
 
-                  if (targetPath.includes('/.next/static/chunks/')) {
-                    // NOTE - in dev mode the request hangs on the error, but the console error should help
-                    // and during a build, it will actually fail the build
-                    (globalThis as any)._dmnoLeakScan(content, {
-                      method: 'nextjs webpack plugin - static chunks',
-                      file: targetPath,
-                    });
-                  }
-                },
-              );
-            }
-          },
-        });
+                    if (targetPath.includes('/.next/static/chunks/')) {
+                      // NOTE - in dev mode the request hangs on the error, but the console error should help
+                      // and during a build, it will actually fail the build
+                      (globalThis as any)._dmnoLeakScan(content, {
+                        method: 'nextjs webpack plugin - static chunks',
+                        file: targetPath,
+                      });
+                    }
+                  },
+                );
+              }
+            },
+          });
 
-        return webpackConfig; // must return the modified config
-      },
+          return webpackConfig; // must return the modified config
+        },
+      };
     };
   };
 }

--- a/packages/integrations/nextjs/tsup.config.ts
+++ b/packages/integrations/nextjs/tsup.config.ts
@@ -28,4 +28,5 @@ export default defineConfig({
   
   splitting: false,
   keepNames: true, // stops build from prefixing our class names with `_` in some cases
+  shims: true,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,6 +599,9 @@ importers:
 
   packages/integrations/nextjs:
     dependencies:
+      import-meta-resolve:
+        specifier: ^4.1.0
+        version: 4.1.0
       next:
         specifier: ^14
         version: 14.2.3(@opentelemetry/api@1.8.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)


### PR DESCRIPTION
- support next config file that returns a function
- add commonjs build, which supports .js and .ts (only .mjs was working)
- improve vercel detection, which triggers inlining config