### PR TITLE
fix plugin input defaults behaviour

### DIFF
--- a/.changeset/nervous-dingos-double.md
+++ b/.changeset/nervous-dingos-double.md
@@ -1,0 +1,7 @@
+---
+"@dmno/1password-plugin": patch
+"@dmno/configraph": patch
+"dmno": patch
+---
+
+fix required behaviour for undefined values, add injection option to allow failure

--- a/packages/configraph/src/resolvers.ts
+++ b/packages/configraph/src/resolvers.ts
@@ -403,13 +403,19 @@ export function processInlineResolverDef(resolverDef: InlineValueResolverDef) {
   } else if (
     _.isString(resolverDef) || _.isNumber(resolverDef) || _.isBoolean(resolverDef)
     || _.isPlainObject(resolverDef)
-    || resolverDef === undefined
   ) {
     return createResolver({
       _typeId: '$static',
       icon: 'bi:dash',
       label: 'static',
-      resolve: async () => resolverDef,
+      resolve: () => resolverDef,
+    });
+  } else if (resolverDef === undefined) {
+    return createResolver({
+      _typeId: '$undefined',
+      icon: 'oui:empty',
+      label: 'undefined',
+      resolve: () => undefined,
     });
   } else {
     throw new Error('invalid resolver definition');

--- a/packages/configraph/src/resolvers/injection.ts
+++ b/packages/configraph/src/resolvers/injection.ts
@@ -2,7 +2,9 @@ import { ConfigraphNode } from '../config-node';
 import { SchemaError } from '../errors';
 import { createResolver } from '../resolvers';
 
-export function inject(injectOpts?: {}) {
+export function inject(injectOpts?: {
+  allowFailure?: boolean,
+}) {
   return createResolver({
     label: 'inject',
     icon: 'fluent:swipe-down-24-regular',
@@ -34,7 +36,9 @@ export function inject(injectOpts?: {}) {
 
       // if we didn't find anything to inject, we'll add a schema error
       if (!matchingNodes.length) {
-        throw new SchemaError(`Injection failed - unable to find match for type ${this.configNode.type.typeLabel}`);
+        if (!injectOpts?.allowFailure) {
+          throw new SchemaError(`Injection failed - unable to find match for type ${this.configNode.type.typeLabel}`);
+        }
       // or if we found multiple matches in the same entity
       // (we could add some options around this?)
       } else if (matchingNodes.length > 1) {

--- a/packages/configraph/test/data-types.test.ts
+++ b/packages/configraph/test/data-types.test.ts
@@ -37,6 +37,12 @@ describe('data types', () => {
 
     const t4 = createConfigraphDataType({ required: true })();
     expect(t4.required).to.eq(true);
+
+    const t5 = createConfigraphDataType({ value: undefined })();
+    expect(t5.required).not.to.eq(true); // currently its undefined, we could make it false instead?
+
+    const t6 = createConfigraphDataType({})();
+    expect(t6.required).not.to.eq(true);
   });
 
   test('validation using settings works', () => {

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -179,14 +179,12 @@ export class OnePasswordDmnoPlugin extends DmnoPlugin {
       });
     }
     // using cli
-    return await ctx.getOrSetCacheItem(`1pass-cli:V|${vaultId}/I|${itemId}`, async () => {
-      const itemJson = await execOpCliCommand([
-        'item', 'get', itemId,
-        `--vault=${vaultId}`,
-        '--format=json',
-      ]);
-      return JSON.parse(itemJson);
-    });
+    const itemJson = await execOpCliCommand([
+      'item', 'get', itemId,
+      `--vault=${vaultId}`,
+      '--format=json',
+    ]);
+    return JSON.parse(itemJson);
   }
 
   private async getOpItemByReference(ctx: ResolverContext, referenceUrl: ReferenceUrl) {
@@ -206,13 +204,11 @@ export class OnePasswordDmnoPlugin extends DmnoPlugin {
       }
     }
     // using op CLI
-    return await ctx.getOrSetCacheItem(`1pass-cli:R|${referenceUrl}`, async () => {
-      return await execOpCliCommand([
-        'read', referenceUrl,
-        '--force',
-        '--no-newline',
-      ]);
-    });
+    return await execOpCliCommand([
+      'read', referenceUrl,
+      '--force',
+      '--no-newline',
+    ]);
   }
 
   private envItemsByService: Record<string, Record<string, string>> | undefined;

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -116,7 +116,7 @@ export class OnePasswordDmnoPlugin extends DmnoPlugin {
         token: {
           description: 'this service account token will be used via the CLI to communicate with 1password',
           extends: OnePasswordTypes.serviceAccountToken,
-          value: inputValues?.token || inject(),
+          value: inputValues?.token || inject({ allowFailure: true }),
           // TODO: add validation, token must be set unless `fallbackToCliBasedAuth` is true
           // required: true,
         },


### PR DESCRIPTION
was using 1password plugin in a new sample project and noticed some issues

**inputs were all being treated as required event though the values were undefined**
turns out even an `undefined` value is treated as a "static resolver", which is what was being looked for to infer an item being required. Added tests for this too.

**service account token injection failing was causing a full failure, even though this plugin is also allowed to use the CLI**
in general, if a user is wiring up something with `inject()` directly, you would expect that it should fail if no match is found. However in the plugin defaults case, where we want to fall back to injection, if the item is not required, we may not want it to cause a failure.

