### PR TITLE
refactor types w/ instance options system

### DIFF
--- a/.changeset/twenty-ladybugs-yawn.md
+++ b/.changeset/twenty-ladybugs-yawn.md
@@ -1,0 +1,6 @@
+---
+"@dmno/configraph": patch
+"dmno": patch
+---
+
+simplify dmno type instance options, skip resolution if override present, add allowMissing to ctx.get, add git vendor types autopopulate

--- a/packages/configraph/src/config-node.ts
+++ b/packages/configraph/src/config-node.ts
@@ -23,7 +23,7 @@ const debug = Debug('configraph:node');
 //! this might be in the wrong place?
 export type ConfigValueOverride = {
   sourceType: string;
-  icon: string;
+  icon?: string;
   sourceLabel?: string;
 
   /** the value of the override */
@@ -297,12 +297,13 @@ export class ConfigraphNode<NodeMetadata = any> {
     // now deal with resolution
     // TODO: need to track dependencies used in coerce/validate/etc
 
-    // TODO: probably want to _skip_ resolution if we have overrides present?
-    const itemResolverCtx = new ResolverContext(this.valueResolver || this);
+    const itemResolverCtx = new ResolverContext((!this.overrides.length && this.valueResolver) || this);
     resolverCtxAls.enterWith(itemResolverCtx);
 
-
-    if (this.valueResolver) {
+    if (this.overrides.length) {
+      this.debug('using override - marking as resolved');
+      this.isResolved = true;
+    } else if (this.valueResolver) {
       if (!this.valueResolver.isFullyResolved) {
         this.debug('running node resolver');
         await this.valueResolver.resolve(itemResolverCtx);

--- a/packages/configraph/src/resolvers.ts
+++ b/packages/configraph/src/resolvers.ts
@@ -461,9 +461,10 @@ export class ResolverContext {
   dependsOnPathsObj: Record<string, boolean> = {};
   get dependsOnPaths() { return _.keys(this.dependsOnPathsObj); }
 
-  get(nodePath: string): any {
+  get(nodePath: string, opts?: { allowMissing?: boolean }): any {
     const node = this.entity?.getConfigNodeByPath(nodePath);
     if (!node) {
+      if (opts?.allowMissing) return;
       throw new Error(`Tried to get config node that does not exist "${nodePath}"`);
     }
 

--- a/packages/configraph/test/data-types.test.ts
+++ b/packages/configraph/test/data-types.test.ts
@@ -62,13 +62,17 @@ describe('data types', () => {
 
   test('check reusing settings in extends', () => {
     const val = 'THEO@DMNO.DEV';
-    // TODO: can make this more clear
-    // internally the email type uses the string type's toLowerCase option
-    const t = ConfigraphBaseTypes.email({ normalize: true });
-    expect(t.coerce(val)).toBe(val.toLowerCase());
 
-    const t2 = ConfigraphBaseTypes.email({ normalize: false });
-    expect(t2.coerce(val)).toBe(val);
+    // check that string can coerce to lowercase
+    const t1 = ConfigraphBaseTypes.string({ toLowerCase: true });
+    expect(t1.coerce(val)).toBe(val.toLowerCase());
+
+    // internally the email type uses the string type's toLowerCase option
+    const t2 = ConfigraphBaseTypes.email({ normalize: true });
+    expect(t2.coerce(val)).toBe(val.toLowerCase());
+
+    const t3 = ConfigraphBaseTypes.email({ normalize: false });
+    expect(t3.coerce(val)).toBe(val);
   });
 
   describe('additional metadata', () => {


### PR DESCRIPTION
While working through some hairy type issues, I noticed simplification of how the type system works with regards to types that have specific instance options. Previously we were attaching those options to the DmnoDataType instance and then making them available on `this` during coercion and validation.

I wanted the settings to be available all the time, and realized I overlooked just using a function in a slightly different way.

End users will not notice anything. This may open the door for further simplification later, but for now it was easier to just leave things mostly as is.

Worked in a few related changes as well
- add `allowMissing` option to ctx.get - useful within vendor schemas where another node _might_ exist
- skip resolution if overrides are present
- add git vendor types ability to autopopulate git sha and branch
