### PR TITLE
1pass-tweaks

### DIFF
--- a/.changeset/orange-jars-talk.md
+++ b/.changeset/orange-jars-talk.md
@@ -1,0 +1,5 @@
+---
+"@dmno/1password-plugin": patch
+---
+
+ensure op cli auth popup only shows once

--- a/.changeset/six-mails-remain.md
+++ b/.changeset/six-mails-remain.md
@@ -1,0 +1,5 @@
+---
+"@dmno/1password-plugin": patch
+---
+
+fix 1pass override loader issue

--- a/example-repo/.dmno/config.mts
+++ b/example-repo/.dmno/config.mts
@@ -39,10 +39,16 @@ export default defineDmnoService({
     processEnvOverrideLoader(),
     // looks for .env files (.env, .env.local, etc)
     dotEnvFileOverrideLoader(),
+    
     // personal overrides, create item in "Employee" vault with this name, item label must match 
     onePasswordOverrideLoader({ reference: 'op://Employee/dmno-local-dev-overrides/root' }, { ignoreMissing: true }),
-    // shared overrides
-    onePasswordOverrideLoader({ reference: 'op://dev test/rznyyjrwcv5sgc4ykjhzpkoevm/root' }),
+    
+    // shared overrides - using the non reference format just to test it
+    onePasswordOverrideLoader({
+      vault: 'dev test',
+      item: 'rznyyjrwcv5sgc4ykjhzpkoevm',
+      field: 'root',
+    }),
   ],
   schema: {
     ITEM_X: { 

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -10,6 +10,43 @@ const ENABLE_BATCHING = true;
 
 const OP_CLI_CACHE: Record<string, any> = {};
 
+
+/*
+  ! IMPORTANT INFO ON CLI AUTH
+
+  Because we trigger multiple requests in parallel, if the app/cli is not unlocked, it will show multiple auth popups.
+  In a big project this is super awkward because you may need to scan your finger over and over again.
+
+  To worka round this, we track if we are currently making the first op cli command, and if so acquire a mutex in the form of
+  a deferred promise that other requests can then wait on. We also use the additional trick of checking `op whoami` so that
+  if the app is already unlocked, we dont have to actually wait for the first request to finish to proceed with the rest.
+
+  Ideally 1password will fix this issue at some point and we can remove this extra logic.
+
+  NOTE - We don't currently do anything special to handle if the user denies the login, or is logged into the wrong account.
+*/
+
+// use a singleton within the module to track op cli auth state as a mutex / deferred promise
+let opAuthDeferred: DeferredPromise<boolean> | undefined;
+async function checkOpCliAuth() {
+  if (opAuthDeferred) {
+    // if the deferred promise already exists, we'll just wait for it to complete
+    await opAuthDeferred.promise;
+  } else {
+    // otherwise it means this is the first call of this function, so we create a new deferred promise
+    // and return the resolve fn to be called after the first CLI method actually completes
+    // except for one further trick, which is to first check if we are already logged in, and resolve right away
+    opAuthDeferred = createDeferredPromise();
+    try {
+      await spawnAsync('op', ['whoami']);
+      opAuthDeferred.resolve(true);
+    } catch (err) {
+      return opAuthDeferred.resolve;
+    }
+  }
+}
+
+
 export async function execOpCliCommand(cmdArgs: Array<string>) {
   // very simple in-memory cache, will persist between runs in watch mode
   // but need to think through how a user can opt out
@@ -22,14 +59,17 @@ export async function execOpCliCommand(cmdArgs: Array<string>) {
 
   const startAt = new Date();
 
+  const authCompletedFn = await checkOpCliAuth();
   try {
     // uses system-installed copy of `op`
     debug('op cli command args', cmdArgs);
     const cliResult = await spawnAsync('op', cmdArgs);
+    authCompletedFn?.(true);
     debug(`> took ${+new Date() - +startAt}ms`);
     // OP_CLI_CACHE[cacheKey] = cliResult;
     return cliResult;
   } catch (err) {
+    authCompletedFn?.(false);
     throw processOpCliError(err);
   }
 }
@@ -132,7 +172,7 @@ function processOpCliError(err: Error | any) {
 let opReadBatch: Record<string, { deferredPromises: Array<DeferredPromise<string>> }> | undefined;
 const BATCH_READ_TIMEOUT = 50;
 
-function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
+async function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
   debug('execute op read batch', Object.keys(batchToExecute));
   const envMap = {} as Record<string, string>;
   let i = 1;
@@ -140,9 +180,11 @@ function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
     envMap[`DMNO_1P_INJECT_${i++}`] = opReference;
   });
   const startAt = new Date();
+
+  const authCompletedFn = await checkOpCliAuth();
   // `env -0` splits values by a null character instead of newlines
   // because otherwise we'll have trouble dealing with values that contain newlines
-  spawnAsync('op', 'run --no-masking -- env -0'.split(' '), {
+  await spawnAsync('op', 'run --no-masking -- env -0'.split(' '), {
     env: {
       // have to pass through at least path so it can find `op`, but might need other items too?
       PATH: process.env.PATH!,
@@ -150,7 +192,8 @@ function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
       ...envMap,
     },
   })
-    .then((result) => {
+    .then(async (result) => {
+      authCompletedFn?.(true);
       debug(`batched OP request took ${+new Date() - +startAt}ms`);
 
       const lines = result.split('\0');
@@ -168,7 +211,9 @@ function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
         });
       }
     })
-    .catch((err) => {
+    .catch(async (err) => {
+      authCompletedFn?.(false);
+
       // have to do special handling of errors because if any IDs are no good, it kills the whole request
       const opErr = processOpCliError(err);
       debug('batch failed', opErr);
@@ -218,7 +263,7 @@ function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>) {
 
       if (Object.keys(batchToExecute).length) {
         debug('re-executing remainder of batch', Object.keys(batchToExecute));
-        executeReadBatch(batchToExecute);
+        await executeReadBatch(batchToExecute);
       }
     });
 }
@@ -245,11 +290,11 @@ export async function opCliRead(opReference: string) {
     opReadBatch[opReference].deferredPromises.push(deferred);
 
     if (shouldExecuteBatch) {
-      setTimeout(() => {
+      setTimeout(async () => {
         if (!opReadBatch) throw Error('expected to find op read batch!');
         const batchToExecute = opReadBatch;
         opReadBatch = undefined;
-        executeReadBatch(batchToExecute);
+        await executeReadBatch(batchToExecute);
       }, BATCH_READ_TIMEOUT);
     }
     return deferred.promise;

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -24,8 +24,8 @@ export async function execOpCliCommand(cmdArgs: Array<string>) {
 
   try {
     // uses system-installed copy of `op`
+    debug('op cli command args', cmdArgs);
     const cliResult = await spawnAsync('op', cmdArgs);
-    debug(`op cli command - "${cmdArgs}"`);
     debug(`> took ${+new Date() - +startAt}ms`);
     // OP_CLI_CACHE[cacheKey] = cliResult;
     return cliResult;

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -38,14 +38,21 @@ async function checkOpCliAuth() {
     // except for one further trick, which is to first check if we are already logged in, and resolve right away
     opAuthDeferred = createDeferredPromise();
     const startAt = new Date();
+    let isLoggedIn: boolean;
     try {
       await spawnAsync('op', ['whoami']);
-      opAuthDeferred.resolve(true);
+      isLoggedIn = true;
     } catch (err) {
+      isLoggedIn = false;
+    }
+
+    const whoamiTime = +new Date() - +startAt;
+    debug(`additional whoami check took ${whoamiTime}ms`);
+
+    if (isLoggedIn) {
+      opAuthDeferred.resolve(true);
+    } else {
       return opAuthDeferred.resolve;
-    } finally {
-      const whoamiTime = +new Date() - +startAt;
-      debug(`additional whoami check took ${whoamiTime}ms`);
     }
   }
 }

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -37,11 +37,15 @@ async function checkOpCliAuth() {
     // and return the resolve fn to be called after the first CLI method actually completes
     // except for one further trick, which is to first check if we are already logged in, and resolve right away
     opAuthDeferred = createDeferredPromise();
+    const startAt = new Date();
     try {
       await spawnAsync('op', ['whoami']);
       opAuthDeferred.resolve(true);
     } catch (err) {
       return opAuthDeferred.resolve;
+    } finally {
+      const whoamiTime = +new Date() - +startAt;
+      debug(`additional whoami check took ${whoamiTime}ms`);
     }
   }
 }

--- a/packages/plugins/1password/src/override-loader.ts
+++ b/packages/plugins/1password/src/override-loader.ts
@@ -9,7 +9,7 @@ type OnePassLocation =
   // reference includes a field already
   { reference: string } |
   // selecting by name is possible without a vault, but will throw an error if multiple items are found
-  { name: string, vault?: string, field?: string } |
+  { item: string, vault?: string, field?: string } |
   { link: string, field?: string };
 
 async function getItemValue(loc: OnePassLocation, defaultFieldName?: string) {
@@ -24,16 +24,16 @@ async function getItemValue(loc: OnePassLocation, defaultFieldName?: string) {
   } else if ('link' in loc) {
     rawItemJson = await execOpCliCommand([
       'item', 'get', loc.link,
-      '--format=json',
+      '--format', 'json',
     ]);
     fieldName = loc.field || defaultFieldName;
-  } else if ('name' in loc) {
+  } else if ('item' in loc) {
     // TODO: handle error when no vault id is provided and more than 1 item is found
     // TODO: also probably ok if zero items were found if looking up by name
     rawItemJson = await execOpCliCommand([
-      'item', 'get', loc.name,
-      ...loc.vault ? [`--vault="${loc.vault}"`] : [],
-      '--format=json',
+      'item', 'get', loc.item,
+      ...loc.vault ? ['--vault', loc.vault] : [],
+      '--format', 'json',
     ]);
     fieldName = loc.field || defaultFieldName;
   } else {

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -126,8 +126,8 @@ export class OnePasswordDmnoPlugin extends DmnoPlugin {
     // using cli
     const itemJson = await execOpCliCommand([
       'item', 'get', itemId,
-      `--vault=${vaultId}`,
-      '--format=json',
+      '--vault', vaultId,
+      '--format', 'json',
     ]);
     return JSON.parse(itemJson);
   }


### PR DESCRIPTION
- fix quote issue with some cases passing args to `op` cli
- ensure 1pass auth popup only shows once, even when making multiple parallel requests
- make more requests batchable
- deprecate pulling overrides from an item without specifying vault id
- renamed `name` to `item` in object format of override location