### PR TITLE
fix: race condition with picked nodes

### DIFF
--- a/.changeset/rare-zebras-cheer.md
+++ b/.changeset/rare-zebras-cheer.md
@@ -1,0 +1,6 @@
+---
+"@dmno/configraph": patch
+"dmno": patch
+---
+
+fix issue with picked nodes and parallelized resolution

--- a/packages/configraph/src/resolvers/pick.ts
+++ b/packages/configraph/src/resolvers/pick.ts
@@ -1,4 +1,4 @@
-import { createResolver } from '../resolvers';
+import { createResolver, DependencyNotResolvedResolutionError } from '../resolvers';
 import { ConfigraphNode } from '../config-node';
 
 export function createdPickedValueResolver(
@@ -15,8 +15,9 @@ export function createdPickedValueResolver(
       // since we handle resolution of services in the right order
       // we can assume the picked value will be resolved already (if it was possible at all)
       if (!sourceNode.isResolved) {
-        return new Error('picked value has not been resolved yet');
+        throw new DependencyNotResolvedResolutionError('picked value has not been resolved yet');
       }
+
       if (valueTransform) {
         return valueTransform(sourceNode.resolvedValue);
       } else {


### PR DESCRIPTION
fixes an issue with picked item resolution that was introduced when parallelized resolution was introduced. It went unnoticed because the pick tests still resolve correctly because everything was so simple. Introducing a short delay in that test recreates the issue.