### PR TITLE
feat: choose workspace config(s) for initializing dmno service

### DIFF
--- a/packages/core/src/cli/commands/init.command.ts
+++ b/packages/core/src/cli/commands/init.command.ts
@@ -5,7 +5,7 @@ import { input, checkbox, confirm } from '@inquirer/prompts';
 import { tryCatch } from '@dmno/ts-lib';
 import Debug from 'debug';
 
-import { findDmnoServices } from '../../config-loader/find-services';
+import { findDmnoServices, selectAndApplyWorkspaceConfig } from '../../config-loader/find-services';
 import { DmnoCommand } from '../lib/dmno-command';
 
 import { joinAndCompact } from '../lib/formatting';
@@ -33,11 +33,13 @@ program.action(async (opts: {
   console.log(DMNO_DEV_BANNER);
   // console.log(kleur.gray('let us help you connect the dots ● ● ●'));
 
-  const [workspaceInfo] = await Promise.all([
+  const [workspaceInfoInitial] = await Promise.all([
     findDmnoServices(true),
     fallingDmnosAnimation(),
   ]);
 
+  // Handle workspace configuration selection after animation completes
+  const workspaceInfo = await selectAndApplyWorkspaceConfig(workspaceInfoInitial);
 
   // await fallingDmnoLoader('● Scanning repo', '● Scan complete');
 

--- a/packages/core/src/config-loader/config-loader.ts
+++ b/packages/core/src/config-loader/config-loader.ts
@@ -12,7 +12,7 @@ import { ViteNodeServer } from 'vite-node/server';
 import { createDeferredPromise } from '@dmno/ts-lib';
 import { createDebugTimer } from '../cli/lib/debug-timer';
 import { setupViteServer } from './vite-server';
-import { ScannedWorkspaceInfo, findDmnoServices } from './find-services';
+import { ScannedWorkspaceInfo, findDmnoServices, selectAndApplyWorkspaceConfig } from './find-services';
 import {
   DmnoService, DmnoWorkspace, DmnoServiceConfig,
 } from '../config-engine/config-engine';
@@ -55,7 +55,8 @@ export class ConfigLoader {
   }
 
   private async finishInit() {
-    this.workspaceInfo = await findDmnoServices();
+    const workspaceInfoInitial = await findDmnoServices();
+    this.workspaceInfo = await selectAndApplyWorkspaceConfig(workspaceInfoInitial);
     // already filtered to only services with a .dmno folder
     const dmnoServicePackages = this.workspaceInfo.workspacePackages;
 


### PR DESCRIPTION
When there are multiple workspace configs found (e.g., bun and Moon):
- if they're equivalent, proceed
- otherwise,  user can choose which one(s) to use for automatically-created dmno configurations

Note: this is a fork of another PR which supports modern workspace configs

## Selection
<img width="784" alt="image" src="https://github.com/user-attachments/assets/301bf4df-bd48-4ecd-b1d2-7e55604774f2" />

## Post Selection
<img width="784" alt="image" src="https://github.com/user-attachments/assets/24a63f5e-629b-4844-876c-c109f26e96f6" />
